### PR TITLE
Clean up linter failures

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -15,7 +15,7 @@ install_wsproto() {
 case "$MODE" in
     flake8)
         pip install flake8
-        flake8 --max-complexity 20 wsproto
+        flake8 --max-complexity 12 wsproto
         ;;
 
     docs)

--- a/test/test_frame_protocol.py
+++ b/test/test_frame_protocol.py
@@ -3,6 +3,7 @@ from binascii import unhexlify
 import struct
 import wsproto.frame_protocol as fp
 
+
 def test_close_with_long_reason():
     # Long close reasons get silently truncated
     proto = fp.FrameProtocol(client=False, extensions=[])


### PR DESCRIPTION
Because I'm a weirdo I've decided to protect the master branch and also to require code reviews and stuff (I know, what a killjoy), but that gets a bit tricky when the linter is failing. So this is a very minor refactor of the code to get the linter back to passing, without breaking tests.

Sometime in the future I'll try to start creeping the test coverage upwards too. =)