### PR TITLE
Only do branch builds on master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-sudo: false
+
+branches:
+  only:
+    - master
 
 env:
   - MODE=pytest


### PR DESCRIPTION
Because the Travis build time is quite long, it'd be much better to reduce the number of builds we have to do. Normally, from branches within the repo, Travis will build them twice: once for the branch, once for the PR. We shouldn't do that: one build is plenty.