### PR TITLE
Allow WSConnection to be initialised with open state

### DIFF
--- a/compliance/test_client.py
+++ b/compliance/test_client.py
@@ -22,7 +22,9 @@ else:
 
 def get_case_count(server):
     uri = urlparse(server + '/getCaseCount')
-    connection = WSConnection(CLIENT, uri.netloc, uri.path)
+    connection = WSConnection(CLIENT,
+                              host=uri.netloc,
+                              resource=uri.path)
     sock = socket.socket()
     sock.connect((uri.hostname, uri.port or 80))
 
@@ -50,7 +52,8 @@ def get_case_count(server):
 def run_case(server, case, agent):
     uri = urlparse(server + '/runCase?case=%d&agent=%s' % (case, agent))
     connection = WSConnection(CLIENT,
-                              uri.netloc, '%s?%s' % (uri.path, uri.query),
+                              host=uri.netloc,
+                              resource='%s?%s' % (uri.path, uri.query),
                               extensions=[PerMessageDeflate()])
     sock = socket.socket()
     sock.connect((uri.hostname, uri.port or 80))
@@ -83,7 +86,8 @@ def run_case(server, case, agent):
 def update_reports(server, agent):
     uri = urlparse(server + '/updateReports?agent=%s' % agent)
     connection = WSConnection(CLIENT,
-                              uri.netloc, '%s?%s' % (uri.path, uri.query))
+                              host=uri.netloc,
+                              resource='%s?%s' % (uri.path, uri.query))
     sock = socket.socket()
     sock.connect((uri.hostname, uri.port or 80))
 

--- a/test/test_upgrade.py
+++ b/test/test_upgrade.py
@@ -10,7 +10,7 @@ import random
 import pytest
 
 from wsproto.compat import PY3
-from wsproto.connection import WSConnection, CLIENT, SERVER
+from wsproto.connection import WSConnection, ConnectionState, CLIENT, SERVER
 from wsproto.events import (
     ConnectionEstablished, ConnectionFailed, ConnectionRequested
 )
@@ -48,7 +48,7 @@ class FakeExtension(Extension):
 
 class TestClientUpgrade(object):
     def initiate(self, host, path, **kwargs):
-        ws = WSConnection(CLIENT, host, path, **kwargs)
+        ws = WSConnection(CLIENT, ConnectionState.CONNECTING, host, path, **kwargs)
 
         data = ws.bytes_to_send()
         request, headers = data.split(b'\r\n', 1)

--- a/wsproto/exceptions.py
+++ b/wsproto/exceptions.py
@@ -1,0 +1,3 @@
+class UnsupportedExtension(Exception):
+    def __init__(self, message=None):
+        super(UnsupportedExtension, self).__init__(message)

--- a/wsproto/extensions.py
+++ b/wsproto/extensions.py
@@ -51,11 +51,11 @@ class PerMessageDeflate(Extension):
         self.client_no_context_takeover = client_no_context_takeover
         if client_max_window_bits is None:
             client_max_window_bits = self.DEFAULT_CLIENT_MAX_WINDOW_BITS
-        self.client_max_window_bits = client_max_window_bits
+        self.client_max_window_bits = int(client_max_window_bits)
         self.server_no_context_takeover = server_no_context_takeover
         if server_max_window_bits is None:
             server_max_window_bits = self.DEFAULT_SERVER_MAX_WINDOW_BITS
-        self.server_max_window_bits = server_max_window_bits
+        self.server_max_window_bits = int(server_max_window_bits)
 
         self._compressor = None
         self._decompressor = None


### PR DESCRIPTION
This PR allows WSConnection objects to be initialised with OPEN state. This allows immediate data transfer which is useful for @mitmproxy which handles the handshake itself.
@Kriechi 
ref: #27 