### PR TITLE
update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,30 @@ Pure Python, pure state-machine WebSocket implementation
     :target: https://codecov.io/gh/python-hyper/wsproto
     :alt: Code coverage
 
-This needs a pile of cleaning up.
+This repository contains a pure-Python implementation of a WebSocket protocol
+stack. It's written from the ground up to be embeddable in whatever program you
+choose to use, ensuring that you can communicate via WebSockets, as defined in
+`RFC6455 <https://tools.ietf.org/html/rfc6455>`_, regardless of your programming
+paradigm.
+
+This repository does not provide a parsing layer, a network layer, or any rules
+about concurrency. Instead, it's a purely in-memory solution, defined in terms
+of data actions and WebSocket frames. RFC6455 and
+
+Compression Extensions for WebSocket via
+`RFC7692 <https://tools.ietf.org/html/rfc7692>`_ are fully supported.
+
+wsproto supports Python 2.7, 3.5 or higher.
+
+To install it, just run:
+
+.. code-block:: console
+
+    $ pip install wsproto
+
+
+Usage
+=====
 
 It passes the autobahn test suite completely and strictly in both client and
 server modes and using permessage-deflate.
@@ -44,6 +67,32 @@ And in another shell run the Autobahn test client:
 
     $ wstest -m fuzzingclient -s ws-fuzzingclient.json
 
-This was written using Python 3.5. Python 3.4, 3.5 and 3.6 are being
-actively tested. PyPy3 will be tested once TravisCI gets it working
-again. Python 2.x is not supported.
+
+Documentation
+=============
+
+Documentation is available at https://wsproto.readthedocs.io/en/latest/.
+
+Contributing
+============
+
+``wsproto`` welcomes contributions from anyone! Unlike many other projects we
+are happy to accept cosmetic contributions and small contributions, in addition
+to large feature requests and changes.
+
+Before you contribute (either by opening an issue or filing a pull request),
+please `read the contribution guidelines`_.
+
+.. _read the contribution guidelines: http://python-hyper.org/en/latest/contributing.html
+
+License
+=======
+
+``wsproto`` is made available under the MIT License. For more details, see the
+``LICENSE`` file in the repository.
+
+Authors
+=======
+
+``wsproto`` was created by @jeamland, and is maintained by the python-hyper
+community.


### PR DESCRIPTION
Most parts of the readme are stolen from the hyper-h2 readme.

fixes #38