### PR TITLE
raise if default args are invalid

### DIFF
--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -34,6 +34,12 @@ class TestConnection(object):
     def test_negotiation(self):
         self.create_connection()
 
+    def test_default_args(self):
+        with pytest.raises(ValueError, match="Host must not be None"):
+            client = WSConnection(CLIENT, resource='/ws')
+        with pytest.raises(ValueError, match="Resource must not be None"):
+            server = WSConnection(CLIENT, host='localhost')
+
     @pytest.mark.parametrize('as_client,final', [
         (True, True),
         (True, False),

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
-pytest==3.0.4
-pytest-cov==2.4.0
-coverage==4.2
+pytest==3.2.1
+pytest-cov==2.5.1
+coverage==4.4.1

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -125,6 +125,12 @@ class WSConnection(object):
             self._upgrade_connection = h11.Connection(h11.SERVER)
 
         if self.client:
+            if self.host is None:
+                raise ValueError(
+                    "Host must not be None for a client-side connection.")
+            if self.resource is None:
+                raise ValueError(
+                    "Resource must not be None for a client-side connection.")
             self.initiate_connection()
 
     def initiate_connection(self):


### PR DESCRIPTION
This prevents weird traceback because `None` can't be encoded with ASCII, and h11 fails if `resource` is `None` when building the request headers.