### PR TITLE
Improve extensions API

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -23,3 +23,5 @@ Extensions
 
 .. autoclass:: wsproto.extensions.Extension
    :members:
+
+.. autodata:: wsproto.extensions.SUPPORTED_EXTENSIONS

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -36,9 +36,9 @@ class TestConnection(object):
 
     def test_default_args(self):
         with pytest.raises(ValueError, match="Host must not be None"):
-            client = WSConnection(CLIENT, resource='/ws')
+            WSConnection(CLIENT, resource='/ws')
         with pytest.raises(ValueError, match="Resource must not be None"):
-            server = WSConnection(CLIENT, host='localhost')
+            WSConnection(CLIENT, host='localhost')
 
     @pytest.mark.parametrize('as_client,final', [
         (True, True),
@@ -136,7 +136,8 @@ class TestConnection(object):
         me.ping(payload)
         wire_data = me.bytes_to_send()
 
-        # Verify that the peer emits the PingReceive event with the correct payload
+        # Verify that the peer emits the PingReceive event with the correct
+        # payload.
         them.receive_bytes(wire_data)
         event = next(them.events())
         assert isinstance(event, PingReceived)
@@ -157,7 +158,8 @@ class TestConnection(object):
             data = wire_data[2:]
         assert data == payload
 
-        # Verify that connection emits the PongReceive event with the correct payload
+        # Verify that connection emits the PongReceive event with the correct
+        # payload.
         me.receive_bytes(wire_data)
         event = next(me.events())
         assert isinstance(event, PongReceived)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands = pytest --cov {envsitepackagesdir}/wsproto --cov-report term-missing -
 
 [testenv:lint]
 basepython = python3.6
-deps = flake8==3.0.4
+deps = flake8==3.4.1
 commands = flake8 --max-complexity 12 wsproto test
 
 [testenv:docs]

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -424,7 +424,7 @@ class WSConnection(object):
                         accept = extension.accept(self, offer)
                         if accept is True:
                             accepts[extension.name] = True
-                        elif accept:
+                        elif accept is not False and accept is not None:
                             accepts[extension.name] = accept.encode('ascii')
 
         if accepts:

--- a/wsproto/extensions.py
+++ b/wsproto/extensions.py
@@ -246,3 +246,11 @@ class PerMessageDeflate(Extension):
         descr = '; '.join(descr)
 
         return '<%s %s>' % (self.__class__.__name__, descr)
+
+#: SUPPORTED_EXTENSIONS maps all supported extension names to their class.
+#: This can be used to iterate all supported extensions of wsproto, instantiate
+#: new extensions based on their name, or check if a given extension is
+#: supported or not.
+SUPPORTED_EXTENSIONS = {
+    PerMessageDeflate.name: PerMessageDeflate
+}

--- a/wsproto/extensions.py
+++ b/wsproto/extensions.py
@@ -247,6 +247,7 @@ class PerMessageDeflate(Extension):
 
         return '<%s %s>' % (self.__class__.__name__, descr)
 
+
 #: SUPPORTED_EXTENSIONS maps all supported extension names to their class.
 #: This can be used to iterate all supported extensions of wsproto, instantiate
 #: new extensions based on their name, or check if a given extension is


### PR DESCRIPTION
and fix a bug where PerMessageDeflate extension would return an empty string in `accept`, but the connection would not send the header back.