### PR TITLE
Bugfix Connection header acceptance

### DIFF
--- a/test/test_upgrade.py
+++ b/test/test_upgrade.py
@@ -386,6 +386,27 @@ class TestServerUpgrade(object):
         assert headers['upgrade'].lower() == 'websocket'
         assert headers['sec-websocket-accept'] == accept_token.decode('ascii')
 
+    def test_correct_request_expanded_connection_header(self):
+        test_host = 'frob.nitz'
+        test_path = '/fnord'
+
+        ws = WSConnection(SERVER)
+
+        nonce = bytes(random.getrandbits(8) for x in range(0, 16))
+        nonce = base64.b64encode(nonce)
+
+        request = b"GET " + test_path.encode('ascii') + b" HTTP/1.1\r\n"
+        request += b'Host: ' + test_host.encode('ascii') + b'\r\n'
+        request += b'Connection: keep-alive, Upgrade\r\n'
+        request += b'Upgrade: WebSocket\r\n'
+        request += b'Sec-WebSocket-Version: 13\r\n'
+        request += b'Sec-WebSocket-Key: ' + nonce + b'\r\n'
+        request += b'\r\n'
+
+        ws.receive_bytes(request)
+        event = next(ws.events())
+        assert isinstance(event, ConnectionRequested)
+
     def test_wrong_method(self):
         test_host = 'frob.nitz'
         test_path = '/fnord'

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -324,7 +324,8 @@ class WSConnection(object):
             return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
                                     "Bad status code from server")
         headers = _normed_header_dict(event.headers)
-        if headers[b'connection'].lower() != b'upgrade':
+        connection_tokens = _split_comma_header(headers[b'connection'])
+        if not any(token.lower() == 'upgrade' for token in connection_tokens):
             return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
                                     "Missing Connection: Upgrade header")
         if headers[b'upgrade'].lower() != b'websocket':
@@ -368,7 +369,8 @@ class WSConnection(object):
             return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
                                     "Request method must be GET")
         headers = _normed_header_dict(event.headers)
-        if headers[b'connection'].lower() != b'upgrade':
+        connection_tokens = _split_comma_header(headers[b'connection'])
+        if not any(token.lower() == 'upgrade' for token in connection_tokens):
             return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
                                     "Missing Connection: Upgrade header")
         if headers[b'upgrade'].lower() != b'websocket':


### PR DESCRIPTION
Some clients, for example Firefox, will send "Connection: keep-alive,
Upgrade" rather than just "Connection: Upgrade". As the previous
version expected the header value to be exactly Upgrade it would raise
a protocol error of "Missing Connection: Upgrade header". This fixes
the issue by accepting any collection of values in the Connection
header that includes "Upgrade".

The relevant part of rfc6455 seems to be in section 4.1:

    The request MUST contain a |Connection| header field whose value
    MUST include the "Upgrade" token.