### PR TITLE
Improve "Getting Started" docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+.pytest_cache
 .python-version
 .tox
 *.egg-info

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,6 +18,48 @@ Connection
 .. autoclass:: wsproto.connection.WSConnection
    :members:
 
+Events
+------
+
+.. autoclass:: wsproto.events.Event
+   :members:
+
+.. autoclass:: wsproto.events.ConnectionRequested
+   :members:
+
+.. autoclass:: wsproto.events.ConnectionEstablished
+   :members:
+
+.. autoclass:: wsproto.events.ConnectionClosed
+   :members:
+
+.. autoclass:: wsproto.events.ConnectionFailed
+   :members:
+
+.. autoclass:: wsproto.events.DataReceived
+   :members:
+
+.. autoclass:: wsproto.events.TextReceived
+   :members:
+
+.. autoclass:: wsproto.events.BytesReceived
+   :members:
+
+.. autoclass:: wsproto.events.PingReceived
+   :members:
+
+.. autoclass:: wsproto.events.PongReceived
+   :members:
+
+Frame Protocol
+--------------
+
+.. autoclass:: wsproto.frame_protocol.Opcode
+   :members:
+
+.. autoclass:: wsproto.frame_protocol.CloseReason
+   :members:
+
 Extensions
 ----------
 

--- a/docs/source/basic-usage.rst
+++ b/docs/source/basic-usage.rst
@@ -5,7 +5,8 @@ This document explains how to get started using wsproto to connect to
 WebSocket servers as well as how to write your own.
 
 We assume some level of familiarity with writing Python and networking code. If
-you're not familiar with these we highly recommend you read up on these first.
+you're not familiar with these we highly recommend `you read up on these first
+<https://docs.python.org/3/howto/sockets.html>`_.
 
 Connections
 -----------
@@ -14,27 +15,118 @@ The main class you'll be working with is the
 :class:`WSConnection <wsproto.connection.WSConnection>` object. This object
 represents a connection to a WebSocket client or server and contains all the
 state needed to communicate with the entity at the other end. Whether you're
-connecting to a server or receiving a connection from a client this is the
+connecting to a server or receiving a connection from a client, this is the
 object you'll use.
 
-The interface to this object is pretty simple. There are some parameters you
-may need to provide at initialisation time and these may vary based on whether
-you're acting as a client or a server. Once created you feed data from the
-network into the connection using the
-:meth:`receive_bytes <wsproto.connection.WSConnection.receive_bytes>` method
-and retrieve data to be sent to the network using the
-:meth:`bytes_to_send <wsproto.connection.WSConnection.bytes_to_send>` method.
-On the other end, protocol events that you can react to arrive via the
-:meth:`events <wsproto.connection.WSConnection.events>` generator method and
-you can send messages back to the other end using the
-:meth:`send_data <wsproto.connection.WSConnection.send_data>` method.
+`wsproto` provides two layers of abstractions. You need to write code that
+interfaces with both of these layers. The following diagram illustrates how your
+code is like a sandwich around `wsproto`.
+
++--------------------+
+| Application        |
++--------------------+
+| <APPLICATION GLUE> |
++--------------------+
+| wsproto            |
++--------------------+
+| <NETWORK GLUE>     |
++--------------------+
+| Network Layer      |
++--------------------+
+
+``wsproto`` does not do perform any network I/O, so ``<NETWORK GLUE>``
+represents the code you need to write to glue ``wsproto`` to the actual network
+layer, i.e. code that can send and receive data over the network. The
+:class:`WSConnection <wsproto.connection.WSConnection>` class provides two
+methods for this purpose. When data has been received on a network socket, you
+feed this data into `wsproto` by calling :meth:`receive_bytes
+<wsproto.connection.WSConnection.receive_bytes>`. When `wsproto` has data that
+needs to be sent over the network, you retrieve that data by calling
+:meth:`bytes_to_send <wsproto.connection.WSConnection.bytes_to_send>`, and your
+code is responsible for actually sending that data over the network.
+
+Internally, ``wsproto`` process the raw network data you feed into it and turns
+it into higher level representations of WebSocket events, such as receiving a
+WebSocket message. In ``<APPLICATION GLUE>``, you need to write code to process
+these events. The :class:`WSConnection <wsproto.connection.WSConnection>` class
+contains a generator method :meth:`events
+<wsproto.connection.WSConnection.events>` that yields WebSocket events. To send
+a message, you call the :meth:`send_data
+<wsproto.connection.WSConnection.send_data>` method.
 
 Connecting to a WebSocket server
 --------------------------------
 
-Some guff about writing clients
+Begin by instantiating a connection object. The ``host`` and ``resource``
+arguments are required to instantiate a client. If the WebSocket server is
+located at ``http://myhost.com/foo``, then you would instantiate the connection
+as follows.
+
+    ws = WSConnection(ConnectionType.CLIENT, host="myhost.com", resource='foo')
+
+Now you need to provide the network glue. For the sake of example, we will use
+standard Python sockets here, but ``wsproto`` can be integrated with any network
+layer::
+
+    stream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    stream.connect(("myhost", 8000))
+
+To read from the network::
+
+    data = stream.recv(4096)
+    ws.receive_bytes(data)
+
+You also need to check if ``wsproto`` has data to send to the network::
+
+    data = ws.bytes_to_send()
+    stream.send(data)
+
+A standard Python socket will block on the call to ``stream.recv()``, so you
+will probably need to use a non-blocking socket or some form of concurrency like
+threading, greenlets, asyncio, etc.
+
+You also need to provide the application glue. To send a WebSocket message::
+
+    ws.send_data("Hello world!")
+
+And to receive WebSocket events::
+
+    for event in ws.events():
+        if isinstance(event, ConnectionEstablished):
+            print('Connection established')
+        elif isinstance(event, ConnectionClosed):
+            print('Connection closed: code={} reason={}'.format(
+                event.code, event.reason))
+        elif isinstance(event, TextReceived):
+            print('Received message: {}'.format(event.data))
+        else:
+            print('Unknown event: {!r}'.format(event))
+
+For a more complete example, see this `toy websocket client
+<https://gist.github.com/mehaase/772efaf451eca7a5c3ce7e72ebaefe4e#file-wsproto_client_sync-py>`_.
 
 WebSocket Servers
 -----------------
 
-Some guff about writing servers.
+A WebSocket server is similar to a client except that it uses a different
+constant::
+
+    ws = WSConnection(ConnectionType.SERVER)
+
+A server also needs to explicitly call the ``accept`` method after it receives a
+``ConnectionRequested`` event::
+
+    for event in ws.events():
+        if isinstance(event, ConnectionRequested):
+            print('Accepting connection request')
+            ws.accept(event)
+        elif isinstance(event, ConnectionClosed):
+            print('Connection closed: code={} reason={}'.format(
+                event.code, event.reason))
+        elif isinstance(event, TextReceived):
+            print('Received message: {}'.format(event.data))
+        else:
+            print('Unknown event: {!r}'.format(event))
+
+For a more complete example, see this `toy websocket server
+<https://gist.github.com/mehaase/772efaf451eca7a5c3ce7e72ebaefe4e#file-wsproto_server_sync-py>`_.

--- a/wsproto/__init__.py
+++ b/wsproto/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 wsproto
-~~~
+~~~~~~~
 
 A WebSocket implementation.
 """

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -25,6 +25,8 @@ from .frame_protocol import FrameProtocol, ParseFailed, CloseReason, Opcode
 # RFC6455, Section 1.3 - Opening Handshake
 ACCEPT_GUID = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
+# RFC6455, Section 4.2.1/6 - Reading the Client's Opening Handshake
+WEBSOCKET_VERSION = b'13'
 
 class ConnectionState(Enum):
     """
@@ -109,8 +111,6 @@ class WSConnection(object):
         self.subprotocols = subprotocols or []
         self.extensions = extensions or []
 
-        self.version = b'13'
-
         self._state = ConnectionState.CONNECTING
         self._close_reason = None
 
@@ -141,7 +141,7 @@ class WSConnection(object):
             b"Upgrade": b'WebSocket',
             b"Connection": b'Upgrade',
             b"Sec-WebSocket-Key": self._nonce,
-            b"Sec-WebSocket-Version": self.version,
+            b"Sec-WebSocket-Version": WEBSOCKET_VERSION,
         }
 
         if self.subprotocols:
@@ -380,8 +380,9 @@ class WSConnection(object):
         if b'sec-websocket-version' not in headers:
             return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
                                     "Missing Sec-WebSocket-Version header")
-        # XX FIXME: need to check Sec-Websocket-Version, and respond with a
-        # 400 if it's not what we expect
+        if headers[b'sec-websocket-version'] != WEBSOCKET_VERSION:
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Unsupported Sec-WebSocket-Version")
 
         if b'sec-websocket-protocol' in headers:
             proposed_subprotocols = _split_comma_header(

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 wsproto/connection
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 An implementation of a WebSocket connection.
 """
@@ -20,7 +20,7 @@ from .events import (
     ConnectionFailed, TextReceived, BytesReceived, PingReceived, PongReceived
 )
 from .frame_protocol import FrameProtocol, ParseFailed, CloseReason, Opcode
-
+from .utilities import normed_header_dict, split_comma_header
 
 # RFC6455, Section 1.3 - Opening Handshake
 ACCEPT_GUID = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
@@ -37,7 +37,6 @@ class ConnectionState(Enum):
     CLOSING = 2
     CLOSED = 3
 
-
 class ConnectionType(Enum):
     CLIENT = 1
     SERVER = 2
@@ -45,31 +44,6 @@ class ConnectionType(Enum):
 
 CLIENT = ConnectionType.CLIENT
 SERVER = ConnectionType.SERVER
-
-
-# Some convenience utilities for working with HTTP headers
-def _normed_header_dict(h11_headers):
-    # This mangles Set-Cookie headers. But it happens that we don't care about
-    # any of those, so it's OK. For every other HTTP header, if there are
-    # multiple instances then you're allowed to join them together with
-    # commas.
-    name_to_values = {}
-    for name, value in h11_headers:
-        name_to_values.setdefault(name, []).append(value)
-    name_to_normed_value = {}
-    for name, values in name_to_values.items():
-        name_to_normed_value[name] = b", ".join(values)
-    return name_to_normed_value
-
-
-# We use this for parsing the proposed protocol list, and for parsing the
-# proposed and accepted extension lists. For the proposed protocol list it's
-# fine, because the ABNF is just 1#token. But for the extension lists, it's
-# wrong, because those can contain quoted strings, which can in turn contain
-# commas. XX FIXME
-def _split_comma_header(value):
-    return [piece.decode('ascii').strip() for piece in value.split(b',')]
-
 
 class WSConnection(object):
     """
@@ -91,13 +65,13 @@ class WSConnection(object):
         as a client.
     :type resource: ``str``
 
-    :param extensions: A list of  extensions to use on this connection.
-        Extensions should be instances of a subclass of
-        :class:`Extension <wsproto.extensions.Extension>`.
+    :param extensions: A list of extensions to use on this connection.
+        Defaults to to an empty list. Extensions should be instances of a
+        subclass of :class:`Extension <wsproto.extensions.Extension>`.
 
     :param subprotocols: A list of subprotocols to request when acting as a
         client, ordered by preference. This has no impact on the connection
-        itself.
+        itself. Defaults to an empty list.
     :type subprotocol: ``list`` of ``str``
     """
 
@@ -173,8 +147,8 @@ class WSConnection(object):
         self-contained message or the last part of a longer message.
 
         If ``payload`` is of type ``bytes`` then the message is flagged as
-        being binary If it is of type ``str`` encoded as UTF-8 and sent as
-        text.
+        being binary. If it is of type ``str`` the message is encoded as UTF-8
+        and sent as text.
 
         :param payload: The message body to send.
         :type payload: ``bytes`` or ``str``
@@ -186,6 +160,13 @@ class WSConnection(object):
         self._outgoing += self._proto.send_data(payload, final)
 
     def close(self, code=CloseReason.NORMAL_CLOSURE, reason=None):
+        """
+        Initiate the close handshake by sending a CLOSE control message.
+
+        A clean teardown requires a CLOSE control messages from the other
+        endpoint before the underlying TCP connection can be closed, see
+        :class:`~wsproto.events.ConnectionClosed`.
+        """
         self._outgoing += self._proto.close(code, reason)
         self._state = ConnectionState.CLOSING
 
@@ -195,27 +176,35 @@ class WSConnection(object):
 
     def bytes_to_send(self, amount=None):
         """
-        Return any data that is to be sent to the remote peer.
+        Returns some data for sending out of the internal data buffer.
 
-        :param amount: (optional) The maximum number of bytes to be provided.
-            If ``None`` or not provided it will return all available bytes.
+        This method is analogous to ``read`` on a file-like object, but it
+        doesn't block. Instead, it returns as much data as the user asks for,
+        or less if that much data is not available. It does not perform any
+        I/O, and so uses a different name.
+
+        :param amount: (optional) The maximum amount of data to return. If not
+            set, or set to ``None``, will return as much data as possible.
         :type amount: ``int``
+        :returns: A bytestring containing the data to send on the wire.
+        :rtype: ``bytes``
         """
-
         if amount is None:
             data = self._outgoing
             self._outgoing = b''
         else:
             data = self._outgoing[:amount]
             self._outgoing = self._outgoing[amount:]
-
         return data
 
     def receive_bytes(self, data):
         """
-        Pass some received bytes to the connection for processing.
+        Pass some received data to the connection for handling.
 
-        :param data: The data received from the remote peer.
+        A list of events that the remote peer triggered by sending this data can
+        be retrieved with :meth:`~wsproto.connection.WSConnection.events`.
+
+        :param data: The data received from the remote peer on the network.
         :type data: ``bytes``
         """
 
@@ -239,35 +228,12 @@ class WSConnection(object):
         if self._state is ConnectionState.OPEN:
             self._proto.receive_bytes(data)
 
-    def _process_upgrade(self, data):
-        self._upgrade_connection.receive_data(data)
-        while True:
-            try:
-                event = self._upgrade_connection.next_event()
-            except h11.RemoteProtocolError:
-                return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                        "Bad HTTP message"), b''
-            if event is h11.NEED_DATA:
-                break
-            elif self.client and isinstance(event, (h11.InformationalResponse,
-                                                    h11.Response)):
-                data = self._upgrade_connection.trailing_data[0]
-                return self._establish_client_connection(event), data
-            elif not self.client and isinstance(event, h11.Request):
-                return self._process_connection_request(event), None
-            else:
-                return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                        "Bad HTTP message"), b''
-
-        self._incoming = b''
-        return None, None
-
     def events(self):
         """
         Return a generator that provides any events that have been generated
         by protocol activity.
 
-        :returns: generator
+        :returns: generator of :class:`Event <wsproto.events.Event>` subclasses
         """
 
         while self._events:
@@ -309,124 +275,9 @@ class WSConnection(object):
             self.close(code=exc.code, reason=str(exc))
             yield ConnectionClosed(exc.code, reason=str(exc))
 
-    def _generate_nonce(self):
-        # os.urandom may be overkill for this use case, but I don't think this
-        # is a bottleneck, and better safe than sorry...
-        self._nonce = base64.b64encode(os.urandom(16))
-
-    def _generate_accept_token(self, token):
-        accept_token = token + ACCEPT_GUID
-        accept_token = hashlib.sha1(accept_token).digest()
-        return base64.b64encode(accept_token)
-
-    def _establish_client_connection(self, event):
-        if event.status_code != 101:
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Bad status code from server")
-        headers = _normed_header_dict(event.headers)
-        connection_tokens = _split_comma_header(headers[b'connection'])
-        if not any(token.lower() == 'upgrade' for token in connection_tokens):
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Missing Connection: Upgrade header")
-        if headers[b'upgrade'].lower() != b'websocket':
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Missing Upgrade: WebSocket header")
-
-        accept_token = self._generate_accept_token(self._nonce)
-        if headers[b'sec-websocket-accept'] != accept_token:
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Bad accept token")
-
-        subprotocol = headers.get(b'sec-websocket-protocol', None)
-        if subprotocol is not None:
-            subprotocol = subprotocol.decode('ascii')
-            if subprotocol not in self.subprotocols:
-                return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                        "unrecognized subprotocol {!r}"
-                                        .format(subprotocol))
-
-        extensions = headers.get(b'sec-websocket-extensions', None)
-        if extensions:
-            accepts = _split_comma_header(extensions)
-
-            for accept in accepts:
-                name = accept.split(';', 1)[0].strip()
-                for extension in self.extensions:
-                    if extension.name == name:
-                        extension.finalize(self, accept)
-                        break
-                else:
-                    return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                            "unrecognized extension {!r}"
-                                            .format(name))
-
-        self._proto = FrameProtocol(self.client, self.extensions)
-        self._state = ConnectionState.OPEN
-        return ConnectionEstablished(subprotocol, extensions)
-
-    def _process_connection_request(self, event):
-        if event.method != b'GET':
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Request method must be GET")
-        headers = _normed_header_dict(event.headers)
-        connection_tokens = _split_comma_header(headers[b'connection'])
-        if not any(token.lower() == 'upgrade' for token in connection_tokens):
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Missing Connection: Upgrade header")
-        if headers[b'upgrade'].lower() != b'websocket':
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Missing Upgrade: WebSocket header")
-
-        if b'sec-websocket-version' not in headers:
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Missing Sec-WebSocket-Version header")
-        if headers[b'sec-websocket-version'] != WEBSOCKET_VERSION:
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Unsupported Sec-WebSocket-Version")
-
-        if b'sec-websocket-protocol' in headers:
-            proposed_subprotocols = _split_comma_header(
-                headers[b'sec-websocket-protocol'])
-        else:
-            proposed_subprotocols = []
-
-        if b'sec-websocket-key' not in headers:
-            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
-                                    "Missing Sec-WebSocket-Key header")
-
-        return ConnectionRequested(proposed_subprotocols, event)
-
-    def _extension_accept(self, extensions_header):
-        accepts = {}
-        offers = _split_comma_header(extensions_header)
-
-        for offer in offers:
-            name = offer.split(';', 1)[0].strip()
-            for extension in self.extensions:
-                if extension.name == name:
-                    accept = extension.accept(self, offer)
-                    if accept is True:
-                        accepts[extension.name] = True
-                    elif accept is not False and accept is not None:
-                        accepts[extension.name] = accept.encode('ascii')
-
-        if accepts:
-            extensions = []
-            for name, params in accepts.items():
-                if params is True:
-                    extensions.append(name.encode('ascii'))
-                else:
-                    # py34 annoyance: doesn't support bytestring formatting
-                    params = params.decode("ascii")
-                    extensions.append(('%s; %s' % (name, params))
-                                      .encode("ascii"))
-            return b', '.join(extensions)
-
-        return None
-
     def accept(self, event, subprotocol=None):
         request = event.h11request
-        request_headers = _normed_header_dict(request.headers)
+        request_headers = normed_header_dict(request.headers)
 
         nonce = request_headers[b'sec-websocket-key']
         accept_token = self._generate_accept_token(nonce)
@@ -478,3 +329,141 @@ class WSConnection(object):
 
         payload = bytes(payload or b'')
         self._outgoing += self._proto.pong(payload)
+
+    def _generate_nonce(self):
+        # os.urandom may be overkill for this use case, but I don't think this
+        # is a bottleneck, and better safe than sorry...
+        self._nonce = base64.b64encode(os.urandom(16))
+
+    def _generate_accept_token(self, token):
+        accept_token = token + ACCEPT_GUID
+        accept_token = hashlib.sha1(accept_token).digest()
+        return base64.b64encode(accept_token)
+
+    def _process_upgrade(self, data):
+        self._upgrade_connection.receive_data(data)
+        while True:
+            try:
+                event = self._upgrade_connection.next_event()
+            except h11.RemoteProtocolError:
+                return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                        "Bad HTTP message"), b''
+            if event is h11.NEED_DATA:
+                break
+            elif self.client and isinstance(event, (h11.InformationalResponse,
+                                                    h11.Response)):
+                data = self._upgrade_connection.trailing_data[0]
+                return self._establish_client_connection(event), data
+            elif not self.client and isinstance(event, h11.Request):
+                return self._process_connection_request(event), None
+            else:
+                return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                        "Bad HTTP message"), b''
+
+        self._incoming = b''
+        return None, None
+
+    def _establish_client_connection(self, event):
+        if event.status_code != 101:
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Bad status code from server")
+        headers = normed_header_dict(event.headers)
+        connection_tokens = split_comma_header(headers[b'connection'])
+        if not any(token.lower() == 'upgrade' for token in connection_tokens):
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Missing Connection: Upgrade header")
+        if headers[b'upgrade'].lower() != b'websocket':
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Missing Upgrade: WebSocket header")
+
+        accept_token = self._generate_accept_token(self._nonce)
+        if headers[b'sec-websocket-accept'] != accept_token:
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Bad accept token")
+
+        subprotocol = headers.get(b'sec-websocket-protocol', None)
+        if subprotocol is not None:
+            subprotocol = subprotocol.decode('ascii')
+            if subprotocol not in self.subprotocols:
+                return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                        "unrecognized subprotocol {!r}"
+                                        .format(subprotocol))
+
+        extensions = headers.get(b'sec-websocket-extensions', None)
+        if extensions:
+            accepts = split_comma_header(extensions)
+
+            for accept in accepts:
+                name = accept.split(';', 1)[0].strip()
+                for extension in self.extensions:
+                    if extension.name == name:
+                        extension.finalize(self, accept)
+                        break
+                else:
+                    return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                            "unrecognized extension {!r}"
+                                            .format(name))
+
+        self._proto = FrameProtocol(self.client, self.extensions)
+        self._state = ConnectionState.OPEN
+        return ConnectionEstablished(subprotocol, extensions)
+
+    def _process_connection_request(self, event):
+        if event.method != b'GET':
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Request method must be GET")
+        headers = normed_header_dict(event.headers)
+        connection_tokens = split_comma_header(headers[b'connection'])
+        if not any(token.lower() == 'upgrade' for token in connection_tokens):
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Missing Connection: Upgrade header")
+        if headers[b'upgrade'].lower() != b'websocket':
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Missing Upgrade: WebSocket header")
+
+        if b'sec-websocket-version' not in headers:
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Missing Sec-WebSocket-Version header")
+        if headers[b'sec-websocket-version'] != WEBSOCKET_VERSION:
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Unsupported Sec-WebSocket-Version")
+
+        if b'sec-websocket-protocol' in headers:
+            proposed_subprotocols = split_comma_header(
+                headers[b'sec-websocket-protocol'])
+        else:
+            proposed_subprotocols = []
+
+        if b'sec-websocket-key' not in headers:
+            return ConnectionFailed(CloseReason.PROTOCOL_ERROR,
+                                    "Missing Sec-WebSocket-Key header")
+
+        return ConnectionRequested(proposed_subprotocols, event)
+
+    def _extension_accept(self, extensions_header):
+        accepts = {}
+        offers = split_comma_header(extensions_header)
+
+        for offer in offers:
+            name = offer.split(';', 1)[0].strip()
+            for extension in self.extensions:
+                if extension.name == name:
+                    accept = extension.accept(self, offer)
+                    if accept is True:
+                        accepts[extension.name] = True
+                    elif accept is not False and accept is not None:
+                        accepts[extension.name] = accept.encode('ascii')
+
+        if accepts:
+            extensions = []
+            for name, params in accepts.items():
+                if params is True:
+                    extensions.append(name.encode('ascii'))
+                else:
+                    # py34 annoyance: doesn't support bytestring formatting
+                    params = params.decode("ascii")
+                    extensions.append(('%s; %s' % (name, params))
+                                      .encode("ascii"))
+            return b', '.join(extensions)
+
+        return None

--- a/wsproto/events.py
+++ b/wsproto/events.py
@@ -47,7 +47,9 @@ class ConnectionEstablished(Event):
 
 class ConnectionClosed(Event):
     """
-    The ConnectionClosed event is fired after the close handshake is complete.
+    The ConnectionClosed event is fired after the connection is considered closed.
+
+    wsproto automatically emits a CLOSE frame when it receives one, to complete the close-handshake.
     """
     def __init__(self, code, reason=None):
         #: The close status code, see :class:`CloseReason

--- a/wsproto/events.py
+++ b/wsproto/events.py
@@ -1,13 +1,20 @@
 # -*- coding: utf-8 -*-
 """
 wsproto/events
-~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 Events that result from processing data on a WebSocket connection.
 """
 
 
-class ConnectionRequested(object):
+class Event(object):
+    """
+    Base class for wsproto events.
+    """
+    pass
+
+
+class ConnectionRequested(Event):
     def __init__(self, proposed_subprotocols, h11request):
         self.proposed_subprotocols = proposed_subprotocols
         self.h11request = h11request
@@ -26,7 +33,7 @@ class ConnectionRequested(object):
                       subprotocol, extensions)
 
 
-class ConnectionEstablished(object):
+class ConnectionEstablished(Event):
     def __init__(self, subprotocol=None, extensions=None):
         self.subprotocol = subprotocol
         self.extensions = extensions
@@ -38,8 +45,13 @@ class ConnectionEstablished(object):
                (self.subprotocol, self.extensions)
 
 
-class ConnectionClosed(object):
+class ConnectionClosed(Event):
+    """
+    The ConnectionClosed event is fired after the close handshake is complete.
+    """
     def __init__(self, code, reason=None):
+        #: The close status code, see :class:`CloseReason
+        #: <wsproto.frame_protocol.CloseReason>`.
         self.code = code
         self.reason = reason
 
@@ -57,7 +69,7 @@ class ConnectionFailed(ConnectionClosed):
     pass
 
 
-class DataReceived(object):
+class DataReceived(Event):
     def __init__(self, data, frame_finished, message_finished):
         self.data = data
         # This has no semantic content, but is provided just in case some
@@ -76,11 +88,11 @@ class BytesReceived(DataReceived):
     pass
 
 
-class PingReceived(object):
+class PingReceived(Event):
     def __init__(self, payload):
         self.payload = payload
 
 
-class PongReceived(object):
+class PongReceived(Event):
     def __init__(self, payload):
         self.payload = payload

--- a/wsproto/events.py
+++ b/wsproto/events.py
@@ -49,6 +49,11 @@ class ConnectionClosed(object):
 
 
 class ConnectionFailed(ConnectionClosed):
+    """
+    The ConnectionFailed event is fired when the upgrade handshake failed.
+    Users must handle this error by appropriate responses to deal with the
+    connection, e.g., sending a 400 HTTP response for a failed client handshake.
+    """
     pass
 
 

--- a/wsproto/extensions.py
+++ b/wsproto/extensions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 wsproto/extensions
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 WebSocket extensions.
 """

--- a/wsproto/frame_protocol.py
+++ b/wsproto/frame_protocol.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 wsproto/frame_protocol
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 WebSocket frame protocol implementation.
 """
@@ -12,7 +12,7 @@ import struct
 from codecs import getincrementaldecoder
 from collections import namedtuple
 
-from enum import Enum, IntEnum
+from enum import IntEnum
 
 from .compat import unicode, Utf8Validator
 
@@ -386,12 +386,6 @@ class FrameDecoder(object):
 
 
 class FrameProtocol(object):
-    class State(Enum):
-        HEADER = 1
-        PAYLOAD = 2
-        FRAME_COMPLETE = 3
-        FAILED = 4
-
     def __init__(self, client, extensions):
         self.client = client
         self.extensions = [ext for ext in extensions if ext.enabled()]
@@ -399,7 +393,7 @@ class FrameProtocol(object):
         # Global state
         self._frame_decoder = FrameDecoder(self.client, self.extensions)
         self._message_decoder = MessageDecoder()
-        self._parse_more = self.parse_more_gen()
+        self._parse_more = self._parse_more_gen()
 
         self._outbound_opcode = None
 
@@ -447,7 +441,7 @@ class FrameProtocol(object):
         return Frame(frame.opcode, data, frame.frame_finished,
                      frame.message_finished)
 
-    def parse_more_gen(self):
+    def _parse_more_gen(self):
         # Consume as much as we can from self._buffer, yielding events, and
         # then yield None when we need more data. Or raise ParseFailed.
 

--- a/wsproto/utilities.py
+++ b/wsproto/utilities.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+wsproto/utilities
+~~~~~~~~~~~~~~~~~
+
+Utility functions that do not belong in a separate module.
+"""
+
+# Some convenience utilities for working with HTTP headers
+def normed_header_dict(h11_headers):
+    # This mangles Set-Cookie headers. But it happens that we don't care about
+    # any of those, so it's OK. For every other HTTP header, if there are
+    # multiple instances then you're allowed to join them together with
+    # commas.
+    name_to_values = {}
+    for name, value in h11_headers:
+        name_to_values.setdefault(name, []).append(value)
+    name_to_normed_value = {}
+    for name, values in name_to_values.items():
+        name_to_normed_value[name] = b", ".join(values)
+    return name_to_normed_value
+
+
+# We use this for parsing the proposed protocol list, and for parsing the
+# proposed and accepted extension lists. For the proposed protocol list it's
+# fine, because the ABNF is just 1#token. But for the extension lists, it's
+# wrong, because those can contain quoted strings, which can in turn contain
+# commas. XX FIXME
+def split_comma_header(value):
+    return [piece.decode('ascii').strip() for piece in value.split(b',')]


### PR DESCRIPTION
For #19, I notice there is already a PR to improve the API docs, but not for the "Getting Started" docs. I spent today getting started with `wsproto`, so I wrote the docs that I wish had existed when I started this morning. It expands the existing prose, adds a diagram, and adds some sample code for clients and servers. Let me know what you think!