### PR TITLE
Fix deflate after a non-compressible message.

### DIFF
--- a/wsproto/extensions.py
+++ b/wsproto/extensions.py
@@ -181,8 +181,10 @@ class PerMessageDeflate(Extension):
         if not fin:
             return None
         if not self._inbound_is_compressible:
+            self._inbound_compressed = None
             return None
         if not self._inbound_compressed:
+            self._inbound_compressed = None
             return None
 
         try:


### PR DESCRIPTION
When a non-compressible opcode, such as a PING was received, self._inbound_compressed
is set to `False`. As long as it is not reset to `None`, no more compression will take
place.

The place where it it is supposed to be reset is `frame_inbound_complete`. However, that
is written such that it bails out and does nothing if the current frame was uncompressed.