### PR TITLE
Fix build failure: update prospector

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -1,6 +1,7 @@
 pylint:
   disable:
     - unused-argument
+    - useless-object-inheritance
 
   options:
     max-args: 6

--- a/compliance/run-autobahn-tests.py
+++ b/compliance/run-autobahn-tests.py
@@ -197,6 +197,7 @@ def main():
 
     coverage_settings["enabled"] = args.cov
     cases = args.cases
+    #pylint: disable=consider-using-get
     if cases in CASES:
         cases = CASES[cases]
     else:
@@ -220,6 +221,7 @@ def main():
         sys.exit(1)
     else:
         say("SUCCESS!")
+
 
 if __name__ == "__main__":
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 
 [testenv:lint]
 basepython = python3.6
-deps = prospector==0.12.7
+deps = prospector==1.1.2
 commands = prospector
 
 [testenv:docs]

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -227,7 +227,7 @@ class WSConnection(object):
             self._events.append(ConnectionClosed(CloseReason.ABNORMAL_CLOSURE))
             self._state = ConnectionState.CLOSED
             return
-        elif data is None:
+        if data is None:
             self._state = ConnectionState.CLOSED
             return
 

--- a/wsproto/extensions.py
+++ b/wsproto/extensions.py
@@ -150,7 +150,7 @@ class PerMessageDeflate(Extension):
     def frame_inbound_header(self, proto, opcode, rsv, payload_length):
         if rsv.rsv1 and opcode.iscontrol():
             return CloseReason.PROTOCOL_ERROR
-        elif rsv.rsv1 and opcode is Opcode.CONTINUATION:
+        if rsv.rsv1 and opcode is Opcode.CONTINUATION:
             return CloseReason.PROTOCOL_ERROR
 
         self._inbound_is_compressible = self._compressible_opcode(opcode)
@@ -180,9 +180,9 @@ class PerMessageDeflate(Extension):
     def frame_inbound_complete(self, proto, fin):
         if not fin:
             return None
-        elif not self._inbound_is_compressible:
+        if not self._inbound_is_compressible:
             return None
-        elif not self._inbound_compressed:
+        if not self._inbound_compressed:
             return None
 
         try:


### PR DESCRIPTION
Fix linter failure [in build #210](https://travis-ci.org/python-hyper/wsproto/builds/424829514), which is caused by incompatible versions of prospector and pylint. This PR updates prospector to 1.1.2 and fixes or disables the new linter errors introduced by this upgrade. 

This is a blocker for #66 (and any other PRs created right now).