### PR TITLE
Revert "Disable hash randomization when running autobahn tests"

### DIFF
--- a/compliance/run-autobahn-tests.py
+++ b/compliance/run-autobahn-tests.py
@@ -4,7 +4,6 @@
 from __future__ import print_function
 
 import sys
-import os
 import os.path
 import argparse
 import errno
@@ -203,12 +202,6 @@ def main():
         cases = CASES[cases]
     else:
         cases = json.loads(cases)
-
-    # The autobahn test suite currently requires hash randomization to be
-    # disabled:
-    #   https://github.com/python-hyper/wsproto/issues/55
-    #   https://github.com/crossbario/autobahn-testsuite/issues/80
-    os.environ["PYTHONHASHSEED"] = "0"
 
     setup_venv()
 


### PR DESCRIPTION
This reverts commit d085adad28c919901ac6a1e0b59bdb0dbe5d6a08 as this
is not required with 0a4339bb95b883aca41e17b344d5e0339be7cae5 which
ensures the autobahn testsuite is >=0.8.0.