### PR TITLE
Continue with the new API, #85, failure handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,9 @@
   information in client mode.
 * Switch from Fail events being returned to RemoteProtocolError`s being
   raised.
+* Switch from ValueError`s to LocalProtocolError`s being raised when
+  an action is taken that is incompatible with the connection state or
+  websocket standard.
 
 0.12.0 2018-09-23
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,6 @@
     ConnectionRequested -> Request
     ConnectionEstablished -> AcceptConnection
     ConnectionClosed -> CloseConnection
-    ConnectionFailed -> Fail
     DataReceived -> Message
     TextReceived -> TextMessage
     BytesReceived -> BytesMessage
@@ -26,6 +25,8 @@
 * Add an extra_headers field to the AcceptConnection event in order to
   customise the acceptance response in server mode or to emit this
   information in client mode.
+* Switch from Fail events being returned to RemoteProtocolError`s being
+  raised.
 
 0.12.0 2018-09-23
 -----------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -39,9 +39,6 @@ Events
 .. autoclass:: wsproto.events.CloseConnection
    :members:
 
-.. autoclass:: wsproto.events.Fail
-   :members:
-
 .. autoclass:: wsproto.events.Message
    :members:
 
@@ -73,3 +70,12 @@ Extensions
    :members:
 
 .. autodata:: wsproto.extensions.SUPPORTED_EXTENSIONS
+
+Exceptions
+----------
+
+.. autoclass:: wsproto.utilities.LocalProtocolError
+   :members:
+
+.. autoclass:: wsproto.utilities.RemoteProtocolError
+   :members:

--- a/docs/source/basic-usage.rst
+++ b/docs/source/basic-usage.rst
@@ -167,6 +167,17 @@ receiving a ``Request`` event.
 For a more complete example, see `synchronous_server.py
 <https://github.com/python-hyper/wsproto/blob/master/example/synchronous_server.py>`_.
 
+Protocol Errors
+---------------
+
+Protocol errors relating to either incorrect data or incorrect state
+changes are raised when the connection receives data or when events
+are sent. A :class:`LocalProtocolError
+<wsproto.utilities.LocalProtocolError>` is raised if the local actions
+are in error whereas a :class:`RemoteProtocolError
+<wsproto.utilities.RemoteProtocolError>` is raised if the remote
+actions are in error.
+
 Closing
 -------
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -16,6 +16,7 @@ from wsproto.events import (
     TextMessage,
 )
 from wsproto.frame_protocol import CloseReason, FrameProtocol
+from wsproto.utilities import LocalProtocolError
 
 
 class TestConnection(object):
@@ -116,7 +117,7 @@ class TestConnection(object):
             next(initiator.events())
 
         completor.send(Ping())
-        with pytest.raises(ValueError):
+        with pytest.raises(LocalProtocolError):
             initiator.receive_bytes(completor.bytes_to_send())
 
     def test_abnormal_closure(self):

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -100,7 +100,7 @@ class TestConnection(object):
         assert isinstance(next(completor.events()), CloseConnection)
 
         # completor enters CLOSED state
-        assert completor.closed
+        assert completor.state is ConnectionState.CLOSED
         with pytest.raises(StopIteration):
             next(completor.events())
 
@@ -111,7 +111,7 @@ class TestConnection(object):
         assert isinstance(next(initiator.events()), CloseConnection)
 
         # initiator enters CLOSED state
-        assert initiator.closed
+        assert initiator.state is ConnectionState.CLOSED
         with pytest.raises(StopIteration):
             next(initiator.events())
 
@@ -127,7 +127,7 @@ class TestConnection(object):
             event = next(conn.events())
             assert isinstance(event, CloseConnection)
             assert event.code is CloseReason.ABNORMAL_CLOSURE
-            assert conn.closed
+            assert conn.state is ConnectionState.CLOSED
 
     def test_bytes_send_all(self):
         connection = WSConnection(SERVER)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -130,6 +130,17 @@ class TestConnection(object):
             assert event.code is CloseReason.ABNORMAL_CLOSURE
             assert conn.state is ConnectionState.CLOSED
 
+    def test_close_before_handshake(self):
+        client = WSConnection(CLIENT)
+        with pytest.raises(LocalProtocolError):
+            client.send(CloseConnection(code=CloseReason.NORMAL_CLOSURE))
+
+    def test_close_when_closing(self):
+        client, _ = self.create_connection()
+        client.send(CloseConnection(code=CloseReason.NORMAL_CLOSURE))
+        with pytest.raises(LocalProtocolError):
+            client.send(CloseConnection(code=CloseReason.NORMAL_CLOSURE))
+
     def test_bytes_send_all(self):
         connection = WSConnection(SERVER)
         connection._outgoing = b"fnord fnord"

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -258,7 +258,7 @@ class WSConnection(object):
         :type data: ``bytes``
         """
 
-        if data is None and self.state is ConnectionState.OPEN:
+        if data is None:
             # "If _The WebSocket Connection is Closed_ and no Close control
             # frame was received by the endpoint (such as could occur if the
             # underlying transport connection is lost), _The WebSocket

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -116,6 +116,10 @@ class WSConnection(object):
         elif isinstance(event, Pong):
             self._outgoing += self._proto.pong(event.payload)
         elif isinstance(event, CloseConnection):
+            if self.state != ConnectionState.OPEN:
+                raise LocalProtocolError(
+                    "Connection cannot be closed in state %s" % self.state
+                )
             self._outgoing += self._proto.close(event.code, event.reason)
             self._state = ConnectionState.CLOSING
 

--- a/wsproto/events.py
+++ b/wsproto/events.py
@@ -181,12 +181,6 @@ class CloseConnection(Event):
     _defaults = {"reason": None}
 
 
-class Fail(CloseConnection):
-    """Indicates the connection handshake has failed."""
-
-    pass
-
-
 class Message(Event):
     """The websocket data message.
 

--- a/wsproto/utilities.py
+++ b/wsproto/utilities.py
@@ -13,6 +13,26 @@ import os
 ACCEPT_GUID = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 
+class ProtocolError(Exception):
+    pass
+
+
+class LocalProtocolError(ProtocolError):
+    pass
+
+
+class RemoteProtocolError(ProtocolError):
+    """Indicates an error due to the remote's actions.
+
+    This is raised when processing the bytes from the remote if the
+    remote has sent data that is incompatible with the websocket
+    standard.
+
+    """
+
+    pass
+
+
 # Some convenience utilities for working with HTTP headers
 def normed_header_dict(h11_headers):
     # This mangles Set-Cookie headers. But it happens that we don't care about

--- a/wsproto/utilities.py
+++ b/wsproto/utilities.py
@@ -18,10 +18,18 @@ class ProtocolError(Exception):
 
 
 class LocalProtocolError(ProtocolError):
+    """Indicates an error due to local/programming errors.
+
+    This is raised when the connection is asked to do something that
+    is either incompatible with the state or the websocket standard.
+
+    """
+
     pass
 
 
 class RemoteProtocolError(ProtocolError):
+
     """Indicates an error due to the remote's actions.
 
     This is raised when processing the bytes from the remote if the


### PR DESCRIPTION
This introduces Local and Remote ProtocolError exceptions that are raised when things go awry do to either the remote or local actions. It replaces ValueError exceptions and the Fail event. It also adapts the principle of #92 to the exceptions named in this pull request (the principle is the same). The naming is taken from h11. Finally the state is exposed as a read only property to allow for any user to know the current connection state.