### PR TITLE
Websocket Version control, replaces #49

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@
 * Switch from ValueError`s to LocalProtocolError`s being raised when
   an action is taken that is incompatible with the connection state or
   websocket standard.
+* Enforce version checking in SERVER mode, only 13 is supported.
 
 0.12.0 2018-09-23
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@
   an action is taken that is incompatible with the connection state or
   websocket standard.
 * Enforce version checking in SERVER mode, only 13 is supported.
+* Add an event_hint to RemoteProtocolErrors to hint at how to respond
+  to issues.
 
 0.12.0 2018-09-23
 -----------------

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -96,7 +96,6 @@ def test_connection_request_bad_upgrade_header():
 
 
 @pytest.mark.parametrize("version", ["12", "not-a-digit"])
-@pytest.mark.skip  # Will fix in a subsequent commit
 def test_connection_request_bad_version_header(version):
     with pytest.raises(RemoteProtocolError) as excinfo:
         event = _make_connection_request(
@@ -108,7 +107,7 @@ def test_connection_request_bad_version_header(version):
                 ("Sec-WebSocket-Key", generate_nonce()),
             ]
         )
-    assert str(excinfo.value) == "Missing header, 'Upgrade: WebSocket'"
+    assert str(excinfo.value) == "Missing header, 'Sec-WebSocket-Version'"
 
 
 def test_connection_request_key_header():

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -108,6 +108,9 @@ def test_connection_request_bad_version_header(version):
             ]
         )
     assert str(excinfo.value) == "Missing header, 'Sec-WebSocket-Version'"
+    assert excinfo.value.event_hint == RejectConnection(
+        headers=[(b"Sec-WebSocket-Version", b"13")], status_code=426
+    )
 
 
 def test_connection_request_key_header():

--- a/wsproto/utilities.py
+++ b/wsproto/utilities.py
@@ -29,16 +29,23 @@ class LocalProtocolError(ProtocolError):
 
 
 class RemoteProtocolError(ProtocolError):
-
     """Indicates an error due to the remote's actions.
 
     This is raised when processing the bytes from the remote if the
     remote has sent data that is incompatible with the websocket
     standard.
 
+    .. attribute:: event_hint
+
+       This is a suggested wsproto Event to send to the client based
+       on the error. It could be None if no hint is available.
+
     """
 
-    pass
+    def __init__(self, message, event_hint=None):
+        # type: (str, Optional[Event]) -> None
+        self.event_hint = event_hint
+        super(RemoteProtocolError, self).__init__(message)
 
 
 # Some convenience utilities for working with HTTP headers


### PR DESCRIPTION
This ensures wsproto errors if the wrong websocket version is used, in addition wsproto provides a hint as to the event to send to the client. This hint is particular useful for a 426 response with a version header.