### PR TITLE
Switch from bytes_to_send to send returning bytes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,14 +2,17 @@
 -----------------
 
 * Introduce a send method on the conenction which accepts the new
-  events. This requires the following usage changes,
+  events. This requires the following usage changes, ::
+
     connection.accept(subprotocol=subprotocol) -> connection.send(AcceptConnection(subprotocol=subprotocol))
     connection.send_data(data) -> connection.send(Message(payload=payload))
     connection.close(code) -> connection.send(CloseConnection(code=code))
     connection.ping() -> connection.send(Ping())
     connection.pong() -> connection.send(Pong())
+
 * The Event structure is altered to allow for events to be sent and
-  received, this requires the following name changes in existing code,
+  received, this requires the following name changes in existing code, ::
+
     ConnectionRequested -> Request
     ConnectionEstablished -> AcceptConnection
     ConnectionClosed -> CloseConnection
@@ -18,6 +21,7 @@
     BytesReceived -> BytesMessage
     PingReceived -> Ping
     PongReceived -> Pong
+
 * Introduce RejectConnection and RejectData events to be used by a
   server connection to reject rather than accept a connection or by a
   client connection to emit the rejection response. The RejectData

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,14 @@
 * Enforce version checking in SERVER mode, only 13 is supported.
 * Add an event_hint to RemoteProtocolErrors to hint at how to respond
   to issues.
+* Switch from a ``bytes_to_send`` method to the ``send`` method
+  returning the bytes to send directly. Responses to Ping and Close
+  messages must now be sent (via ``send``), with the ``Ping`` and
+  ``CloseConnection`` events gaining a ``response`` method. This
+  allows ::
+
+    if isinstance(event, Ping):
+        bytes_to_send = connection.send(event.response())
 
 0.12.0 2018-09-23
 -----------------

--- a/docs/source/basic-usage.rst
+++ b/docs/source/basic-usage.rst
@@ -36,16 +36,17 @@ code is like a sandwich around `wsproto`.
 | Network Layer      |
 +--------------------+
 
-`wsproto` does not do perform any network I/O, so ``<NETWORK GLUE>`` represents
-the code you need to write to glue `wsproto` to the actual network layer, i.e.
-code that can send and receive data over the network. The
-:class:`WSConnection <wsproto.connection.WSConnection>` class provides two
-methods for this purpose. When data has been received on a network socket, you
-feed this data into `wsproto` by calling :meth:`receive_bytes
-<wsproto.connection.WSConnection.receive_bytes>`. When `wsproto` has data that
-needs to be sent over the network, you retrieve that data by calling
-:meth:`bytes_to_send <wsproto.connection.WSConnection.bytes_to_send>`, and your
-code is responsible for actually sending that data over the network.
+`wsproto` does not do perform any network I/O, so ``<NETWORK GLUE>``
+represents the code you need to write to glue `wsproto` to the actual
+network layer, i.e.  code that can send and receive data over the
+network. The :class:`WSConnection <wsproto.connection.WSConnection>`
+class provides two methods for this purpose. When data has been
+received on a network socket, you feed this data into `wsproto` by
+calling :meth:`receive_bytes
+<wsproto.connection.WSConnection.receive_bytes>`. When `wsproto` sends
+events the :meth:`send <wsproto.connection.WSConnection.send>` will
+return the bytes that need to be sent over the network. Your code is
+responsible for actually sending that data over the network.
 
 .. note::
 
@@ -85,14 +86,10 @@ To read from the network::
     data = stream.recv(4096)
     ws.receive_bytes(data)
 
-You also need to check if `wsproto` has data to send to the network::
+You also need to send data returned by the send method::
 
-    data = ws.bytes_to_send()
+    data = ws.send(Message(data=b"Hello"))
     stream.send(data)
-
-Note that ``bytes_to_send()`` will return zero bytes if the protocol has no
-pending data. You can either poll this method or call it only when you expect
-to have pending data.
 
 A standard Python socket will block on the call to ``stream.recv()``, so you
 will probably need to use a non-blocking socket or some form of concurrency like

--- a/example/synchronous_client.py
+++ b/example/synchronous_client.py
@@ -50,7 +50,8 @@ def wsproto_demo(host, port):
     # 1) Negotiate WebSocket opening handshake
     print('Opening WebSocket')
     ws = WSConnection(ConnectionType.CLIENT)
-    ws.send(Request(host=host, target='server'))
+    net_send(ws.send(Request(host=host, target='server')), conn)
+    net_recv(ws, conn)
 
     # events is a generator that yields websocket event objects. Usually you
     # would say `for event in ws.events()`, but the synchronous nature of this
@@ -62,7 +63,6 @@ def wsproto_demo(host, port):
 
     # Because this is a client WebSocket, wsproto has automatically queued up
     # a handshake, and we need to send it and wait for a response.
-    net_send_recv(ws, conn)
     event = next(events)
     if isinstance(event, AcceptConnection):
         print('WebSocket negotiation complete')
@@ -72,8 +72,8 @@ def wsproto_demo(host, port):
     # 2) Send a message and display response
     message = "wsproto is great"
     print('Sending message: {}'.format(message))
-    ws.send(Message(data=message))
-    net_send_recv(ws, conn)
+    net_send(ws.send(Message(data=message)), conn)
+    net_recv(ws, conn)
     event = next(events)
     if isinstance(event, TextMessage):
         print('Received message: {}'.format(event.data))
@@ -83,8 +83,8 @@ def wsproto_demo(host, port):
     # 3) Send ping and display pong
     payload = b"table tennis"
     print('Sending ping: {}'.format(payload))
-    ws.send(Ping(payload=payload))
-    net_send_recv(ws, conn)
+    net_send(ws.send(Ping(payload=payload)), conn)
+    net_recv(ws, conn)
     event = next(events)
     if isinstance(event, Pong):
         print('Received pong: {}'.format(event.payload))
@@ -93,18 +93,17 @@ def wsproto_demo(host, port):
 
     # 4) Negotiate WebSocket closing handshake
     print('Closing WebSocket')
-    ws.send(CloseConnection(code=1000, reason='sample reason'))
+    net_send(ws.send(CloseConnection(code=1000, reason='sample reason')), conn)
     # After sending the closing frame, we won't get any more events. The server
     # should send a reply and then close the connection, so we need to receive
     # twice:
-    net_send_recv(ws, conn)
+    net_recv(ws, conn)
     conn.shutdown(socket.SHUT_WR)
     net_recv(ws, conn)
 
 
-def net_send(ws, conn):
+def net_send(out_data, conn):
     ''' Write pending data from websocket to network. '''
-    out_data = ws.bytes_to_send()
     print('Sending {} bytes'.format(len(out_data)))
     conn.send(out_data)
 
@@ -120,12 +119,6 @@ def net_recv(ws, conn):
     else:
         print('Received {} bytes'.format(len(in_data)))
         ws.receive_bytes(in_data)
-
-
-def net_send_recv(ws, conn):
-    ''' Send pending data and then wait for response. '''
-    net_send(ws, conn)
-    net_recv(ws, conn)
 
 
 if __name__ == '__main__':

--- a/example/synchronous_server.py
+++ b/example/synchronous_server.py
@@ -81,26 +81,27 @@ def handle_connection(stream):
         if isinstance(event, Request):
             # Negotiate new WebSocket connection
             print('Accepting WebSocket upgrade')
-            ws.send(AcceptConnection())
+            out_data = ws.send(AcceptConnection())
         elif isinstance(event, CloseConnection):
             # Print log message and break out
             print('Connection closed: code={}/{} reason={}'.format(
                 event.code.value, event.code.name, event.reason))
+            out_data = ws.send(event.response())
             running = False
         elif isinstance(event, TextMessage):
             # Reverse text and send it back to wsproto
             print('Received request and sending response')
-            ws.send(Message(data=event.data[::-1]))
+            out_data = ws.send(Message(data=event.data[::-1]))
         elif isinstance(event, Ping):
             # wsproto handles ping events for you by placing a pong frame in
             # the outgoing buffer. You should not call pong() unless you want to
             # send an unsolicited pong frame.
             print('Received ping and sending pong')
+            out_data = ws.send(event.response())
         else:
             print('Unknown event: {!r}'.format(event))
 
         # 4) Send data from wsproto to network
-        out_data = ws.bytes_to_send()
         print('Sending {} bytes'.format(len(out_data)))
         stream.send(out_data)
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -19,8 +19,7 @@ def _make_connection_request(request):
     # type: (Request) -> h11.Request
     client = WSConnection(CLIENT)
     server = h11.Connection(h11.SERVER)
-    client.send(request)
-    server.receive_data(client.bytes_to_send())
+    server.receive_data(client.send(request))
     return server.next_event()
 
 
@@ -103,15 +102,16 @@ def _make_handshake(
 ):
     client = WSConnection(CLIENT)
     server = h11.Connection(h11.SERVER)
-    client.send(
-        Request(
-            host="localhost",
-            target="/",
-            subprotocols=subprotocols or [],
-            extensions=extensions or [],
+    server.receive_data(
+        client.send(
+            Request(
+                host="localhost",
+                target="/",
+                subprotocols=subprotocols or [],
+                extensions=extensions or [],
+            )
         )
     )
-    server.receive_data(client.bytes_to_send())
     request = server.next_event()
     if auto_accept_key:
         full_request_headers = normed_header_dict(request.headers)
@@ -232,8 +232,7 @@ def test_protocol_error():
 def _make_handshake_rejection(status_code, body=None):
     client = WSConnection(CLIENT)
     server = h11.Connection(h11.SERVER)
-    client.send(Request(host="localhost", target="/"))
-    server.receive_data(client.bytes_to_send())
+    server.receive_data(client.send(Request(host="localhost", target="/")))
     headers = []
     if body is not None:
         headers.append(("Content-Length", str(len(body))))

--- a/wsproto/events.py
+++ b/wsproto/events.py
@@ -180,6 +180,9 @@ class CloseConnection(Event):
     _fields = ["code", "reason"]
     _defaults = {"reason": None}
 
+    def response(self):
+        return CloseConnection(code=self.code, reason=self.reason)
+
 
 class Message(Event):
     """The websocket data message.
@@ -240,6 +243,9 @@ class Ping(Event):
 
     _fields = ["payload"]
     _defaults = {"payload": b""}
+
+    def response(self):
+        return Pong(payload=self.payload)
 
 
 class Pong(Event):


### PR DESCRIPTION
This implements the ideas in #91.

This allows the outgoing_data buffer to be removed and instead left to the user to be concerned/deal with. This makes it very clear when wsproto has bytes to send (when ``send`` is called), and hence further clarifies the API. It also matches h11 expectations.