### PR TITLE
Bump and release 0.13.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.13.0 Unreleased
+0.13.0 2019-01-22
 -----------------
 
 * Introduce a send method on the conenction which accepts the new

--- a/wsproto/__init__.py
+++ b/wsproto/__init__.py
@@ -8,7 +8,7 @@ A WebSocket implementation.
 from .connection import ConnectionType
 from .handshake import H11Handshake
 
-__version__ = "0.12.0+dev"
+__version__ = "0.13.0"
 
 
 class WSConnection(object):


### PR DESCRIPTION
I think now is a good time to release.

Note, the next bit of work is a `H2Handshake` which can't start till https://github.com/python-hyper/hyper-h2/pull/1178 is accepted (in some form) and Hyper-h2 is released.

@Kriechi @mehaase happy for me to release?