### PR TITLE
Support HTTP/2 WebSockets

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -24,7 +24,9 @@ Handshake
 .. autoclass:: wsproto.handshake.H11Handshake
    :members:
 
-.. autofunction:: wsproto.handshake.handshake_extensions
+.. autofunction:: wsproto.handshake.client_extensions_handshake
+
+.. autofunction:: wsproto.handshake.server_extensions_handshake
 
 Events
 ------


### PR DESCRIPTION
This only includes helper functions for the handshake phase. This is
because the HTTP/2 connection must be managed alongside the chosen I/O
(in order for the flow control to work). The recommendation is to use
the Hyper-h2 library with wsproto.

In order to support h2 client extension handshakes the
handshake_extensions function has been renamed.

See #109 and #102 for previous discussion.