### PR TITLE
Bugfix clarify the subprotocol type in events

### DIFF
--- a/wsproto/events.py
+++ b/wsproto/events.py
@@ -76,7 +76,7 @@ class Request(Event):
 
        The hostname, or host header value.
 
-    .. attribute:: subprotocols
+    .. attribute:: subprotocols List[str]
 
        A list of subprotocols ordered by preference.
 
@@ -104,6 +104,10 @@ class AcceptConnection(Event):
 
        Any additional (non websocket related) headers present in the
        acceptance response.
+
+    .. attribute: subprotocol (Optional[str])
+
+       The accepted subprotocol to use. Optional.
 
     """
 

--- a/wsproto/handshake.py
+++ b/wsproto/handshake.py
@@ -248,7 +248,9 @@ class H11Handshake(object):
                 raise LocalProtocolError(
                     "unexpected subprotocol {}".format(event.subprotocol)
                 )
-            headers.append((b"Sec-WebSocket-Protocol", event.subprotocol))
+            headers.append(
+                (b"Sec-WebSocket-Protocol", event.subprotocol.encode("ascii"))
+            )
 
         if event.extensions:
             accepts = handshake_extensions(
@@ -314,7 +316,12 @@ class H11Handshake(object):
         ]
 
         if request.subprotocols:
-            headers.append((b"Sec-WebSocket-Protocol", ", ".join(request.subprotocols)))
+            headers.append(
+                (
+                    b"Sec-WebSocket-Protocol",
+                    (", ".join(request.subprotocols)).encode("ascii"),
+                )
+            )
 
         if request.extensions:
             offers = {e.name: e.offer() for e in request.extensions}


### PR DESCRIPTION
The correct type is a string (not bytes), this clarifies it througout
and ensures the encoding/decoding is clear. Note that this was unlikely
to cause errors previously given h11 would encode.