### PR TITLE
Loosen the h11 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     ],
     install_requires=[
         "dataclasses ; python_version < '3.7'",
-        'h11 ~= 0.8.1',  # means: 0.8.x where x >= 1
+        'h11 >= 0.8.1',
     ],
 )


### PR DESCRIPTION
h11 0.9.0 is also compatible with wsproto, therefore >= 0.8.1 is
better defined.