### PR TITLE
Improve docs for RejectConnection and RejectData (closes #121)

### DIFF
--- a/wsproto/events.py
+++ b/wsproto/events.py
@@ -92,9 +92,22 @@ class AcceptConnection(Event):
 class RejectConnection(Event):
     """The rejection of a Websocket upgrade request, the HTTP response.
 
-    This event is fired when a CLIENT receives a rejection response
-    from a server. It can be used to reject a request when sent from
-    as SERVER. If has_body is False the headers must include a
+    The ``RejectConnection`` event sends the appropriate HTTP headers to
+    communicate to the peer that the handshake has been rejected. You may also
+    send an HTTP body by setting the ``has_body`` attribute to ``True`` and then
+    sending one or more :class:`RejectData` events after this one. When sending
+    a response body, the caller should set the ``Content-Length``,
+    ``Content-Type``, and/or ``Transfer-Encoding`` headers as appropriate.
+
+    When receiving a ``RejectConnection`` event, the ``has_body`` attribute will
+    in almost all cases be ``True`` (even if the server set it to ``False``) and
+    will be followed by at least one ``RejectData`` events, even though the data
+    itself might be just ``b""``. (The only scenario in which the caller
+    receives a ``RejectConnection`` with ``has_body == False`` is if the peer
+    violates sends an informational status code (1xx) other than 101.)
+
+    The ``has_body`` attribute should only be used when receiving the event. (It
+    has ) is False the headers must include a
     content-length or transfer encoding.
 
     Fields:
@@ -122,6 +135,9 @@ class RejectConnection(Event):
 @dataclass(frozen=True)
 class RejectData(Event):
     """The rejection HTTP response body.
+
+    The caller may send multiple ``RejectData`` events. The final event should
+    have the ``body_finished`` attribute set to ``True``.
 
     Fields:
 


### PR DESCRIPTION
Clarify how these two classes interact, and also add explanation
for what has_body means when sending vs. receiving.