### PR TITLE
remove test package from installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author='Benno Rice',
     author_email='benno@jeamland.net',
     url='https://github.com/python-hyper/wsproto/',
-    packages=find_packages(),
+    packages=find_packages(exclude=['test']),
     package_data={'': ['LICENSE', 'README.rst']},
     package_dir={'wsproto': 'wsproto'},
     python_requires=">=3.6.1",


### PR DESCRIPTION
The `test` package was installed by default, which is generally not what is wanted. This PR removes it from the install.