### PR TITLE
Switch to aiohttp masking method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,21 +24,21 @@ matrix:
       dist: xenial
       sudo: true # required workaround for https://github.com/travis-ci/travis-ci/issues/9815
     - python: 3.6
-      env: TOXENV=py36 EXTRA_DEPS=wsaccel
+      env: TOXENV=py36
     - python: 3.7
-      env: TOXENV=py37 EXTRA_DEPS=wsaccel
+      env: TOXENV=py37
       dist: xenial
       sudo: true # required workaround for https://github.com/travis-ci/travis-ci/issues/9815
     - python: 3.6
-      env: TOXENV=autobahn EXTRA_DEPS=wsaccel SIDE=client
+      env: TOXENV=autobahn SIDE=client
     - python: 3.7
-      env: TOXENV=autobahn EXTRA_DEPS=wsaccel SIDE=client
+      env: TOXENV=autobahn SIDE=client
       dist: xenial
       sudo: true # required workaround for https://github.com/travis-ci/travis-ci/issues/9815
     - python: 3.6
-      env: TOXENV=autobahn EXTRA_DEPS=wsaccel SIDE=server
+      env: TOXENV=autobahn SIDE=server
     - python: 3.7
-      env: TOXENV=autobahn EXTRA_DEPS=wsaccel SIDE=server
+      env: TOXENV=autobahn SIDE=server
       dist: xenial
       sudo: true # required workaround for https://github.com/travis-ci/travis-ci/issues/9815
 

--- a/README.rst
+++ b/README.rst
@@ -92,9 +92,6 @@ Testing
 It passes the autobahn test suite completely and strictly in both client and
 server modes and using permessage-deflate.
 
-If `wsaccel <https://pypi.python.org/pypi/wsaccel>`_ is installed
-(optional), then it will be used to speed things up.
-
 If you want to run the compliance tests, go into the compliance directory and
 then to test client mode, in one shell run the Autobahn test server:
 

--- a/test/test_frame_protocol.py
+++ b/test/test_frame_protocol.py
@@ -1192,3 +1192,10 @@ class TestFrameProtocolSend:
         with pytest.raises(ValueError):
             # Intentionally passing illegal type.
             proto.send_data(payload)  # type: ignore
+
+
+def test_xor_mask_simple() -> None:
+    masker = fp.XorMaskerSimple(b"1234")
+    assert masker.process(b"some very long data for masking by websocket") == (
+        b"B]^Q\x11DVFH\x12_[_U\x13PPFR\x14W]A\x14\\S@_X\\T\x14SK\x13CTP@[RYV@"
+    )


### PR DESCRIPTION
This utilises the masking method used in aiohttp as it has better
performance, in addition the aiohttp test is also used. With thanks to
@willmcgugan for the original implementation.

This also makes it more explicit that wsaccel is an optional extra, by
adding it as an extra requirement in the setup.py.