### PR TITLE
fix tox envs with broken dependencies

### DIFF
--- a/test/test_extensions.py
+++ b/test/test_extensions.py
@@ -1,5 +1,4 @@
-import wsproto.extensions as wpext
-import wsproto.frame_protocol as fp
+from wsproto import extensions as wpext, frame_protocol as fp
 
 
 class TestExtension:

--- a/test/test_frame_protocol.py
+++ b/test/test_frame_protocol.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import itertools
 import struct
 from binascii import unhexlify
@@ -8,8 +7,7 @@ from typing import Dict, Optional, Tuple, Union
 
 import pytest
 
-import wsproto.extensions as wpext
-import wsproto.frame_protocol as fp
+from wsproto import extensions as wpext, frame_protocol as fp
 
 
 class TestBuffer:

--- a/test/test_permessage_deflate.py
+++ b/test/test_permessage_deflate.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
-
 import zlib
 from typing import cast, Dict, Optional, Sequence, TYPE_CHECKING, Union
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-import wsproto.extensions as wpext
-import wsproto.frame_protocol as fp
+from wsproto import extensions as wpext, frame_protocol as fp
 
 if TYPE_CHECKING:
     from mypy_extensions import TypedDict

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,11 @@ commands =
 [testenv:format]
 basepython = python3.8
 deps =
-    black
-    isort
+    black==19.10b0
+    isort==5.0.3
 commands =
     black --check --diff src/wsproto/ test/ example/ compliance/
-    isort --dont-skip __init__.py --diff --check --settings-path setup.cfg --recursive src/wsproto test example compliance
+    isort --check --diff src/wsproto/ test/ example/ compliance/
 
 [testenv:mypy]
 basepython = python3.8
@@ -42,12 +42,13 @@ commands =
 [testenv:lint]
 basepython = python3.8
 deps =
-    prospector
+    prospector==1.3.0
 commands = prospector
 
 [testenv:docs]
 basepython = python3.8
-deps = sphinx==3.0.3
+deps =
+    sphinx==3.0.3
 whitelist_externals = make
 changedir = {toxinidir}/docs
 commands =


### PR DESCRIPTION
isort recently pushed a new major update which caused problems. This PR includes:
  * updates the dependency to the latest version
  * addresses the newly reported linting issues
  * pin all dependencies inside `tox.ini`, this allows requires.io and others to work better with CI/CD