### PR TITLE
Correct project name in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ with open(os.path.join(PROJECT_ROOT, '../../', 'src/wsproto/__init__.py')) as fi
 
 # -- Project information -----------------------------------------------------
 
-project = 'hpack'
+project = 'wsproto'
 copyright = '2020, Benno Rice'
 author = 'Benno Rice'
 release = version


### PR DESCRIPTION
Trivial fix to correct the name in the readthedocs page:
![image](https://user-images.githubusercontent.com/3187637/93320395-51e02d00-f811-11ea-8f5d-fe6066980c8a.png)
