### PR TITLE
Add a simple connection benchmark

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ graft compliance
 graft example
 graft docs
 graft test
+graft bench
 prune docs/build
 prune compliance/reports
 prune compliance/auto-tests-server-config.json

--- a/bench/connection.py
+++ b/bench/connection.py
@@ -1,0 +1,57 @@
+import random
+import time
+from typing import List
+
+import wsproto
+
+random_seed = 0
+mu = 125 * 1024
+sigma = 75 * 1024
+iterations = 5000
+per_message_deflate = False
+
+
+rand = random.Random(random_seed)
+
+
+client_extensions: List[wsproto.extensions.Extension] = []
+if per_message_deflate:
+    pmd = wsproto.extensions.PerMessageDeflate()
+    offer = pmd.offer()
+    assert isinstance(offer, str)
+    pmd.finalize(offer)
+    client_extensions.append(pmd)
+client = wsproto.connection.Connection(
+    wsproto.ConnectionType.CLIENT,
+    extensions=client_extensions,
+)
+
+
+server_extensions: List[wsproto.extensions.Extension] = []
+if per_message_deflate:
+    pmd = wsproto.extensions.PerMessageDeflate()
+    offer = pmd.offer()
+    assert isinstance(offer, str)
+    pmd.accept(offer)
+server = wsproto.connection.Connection(
+    wsproto.ConnectionType.SERVER,
+    extensions=server_extensions,
+)
+
+
+start = time.perf_counter()
+for i in range(iterations):
+    client_msg = b"0" * max(0, round(rand.gauss(mu, sigma)))
+    client_out = client.send(wsproto.events.BytesMessage(client_msg))
+    server.receive_data(client_out)
+    for event in server.events():
+        pass
+
+    server_msg = "0" * max(0, round(rand.gauss(mu, sigma)))
+    server_out = server.send(wsproto.events.TextMessage(server_msg))
+    client.receive_data(server_out)
+    for event in client.events():
+        pass
+end = time.perf_counter()
+
+print(f"{end - start:.4f}s")

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,8 @@ deps =
     black==20.8b1
     isort==5.4.2
 commands =
-    black --check --diff src/ test/ example/ compliance/
-    isort --check --diff src/ test/ example/ compliance/
+    black --check --diff src/ test/ example/ compliance/ bench/
+    isort --check --diff src/ test/ example/ compliance/ bench/
 
 [testenv:mypy]
 basepython = python3.8
@@ -42,7 +42,7 @@ deps =
     mypy==0.790
     pytest==6.1.2
 commands =
-    mypy src/ test/ example/
+    mypy src/ test/ example/ bench/
 
 [testenv:lint]
 basepython = python3.8


### PR DESCRIPTION
Fixes #128.

Doesn't check handshake at all. Bounces some normally-distributed text & bytes messages between a server and client connections. Optionally enable the permessage deflate extension. Pretty simplistic but better than nothing.