### PR TITLE
Require newer h11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'h11>=0.9.0,<1',
+        'h11>=0.13.0,<1',
     ],
 )


### PR DESCRIPTION
The test suite currently doesn't run with older h11:

```
==================================== ERRORS ====================================
_____________________ ERROR collecting test/test_server.py _____________________
test/test_server.py:289: in <module>
    ) -> List[h11.Event]:
E   AttributeError: module 'h11' has no attribute 'Event'
```

Although `h11.Event` is only used in the test suite, I think we shouldn't declare support for versions we cannot test with.