### PR TITLE
Make the value of the upgrade header the same as the RFC.

### DIFF
--- a/src/wsproto/handshake.py
+++ b/src/wsproto/handshake.py
@@ -235,7 +235,7 @@ class H11Handshake:
             )
         if upgrade.lower() != b"websocket":
             raise RemoteProtocolError(
-                "Missing header, 'Upgrade: WebSocket'", event_hint=RejectConnection()
+                "Missing header, 'Upgrade: websocket'", event_hint=RejectConnection()
             )
         if host is None:
             raise RemoteProtocolError(
@@ -260,7 +260,7 @@ class H11Handshake:
         accept_token = generate_accept_token(nonce)
 
         headers = [
-            (b"Upgrade", b"WebSocket"),
+            (b"Upgrade", b"websocket"),
             (b"Connection", b"Upgrade"),
             (b"Sec-WebSocket-Accept", accept_token),
         ]
@@ -327,7 +327,7 @@ class H11Handshake:
 
         headers = [
             (b"Host", request.host.encode("idna")),
-            (b"Upgrade", b"WebSocket"),
+            (b"Upgrade", b"websocket"),
             (b"Connection", b"Upgrade"),
             (b"Sec-WebSocket-Key", self._nonce),
             (b"Sec-WebSocket-Version", WEBSOCKET_VERSION),
@@ -404,7 +404,7 @@ class H11Handshake:
             )
         if upgrade.lower() != b"websocket":
             raise RemoteProtocolError(
-                "Missing header, 'Upgrade: WebSocket'", event_hint=RejectConnection()
+                "Missing header, 'Upgrade: websocket'", event_hint=RejectConnection()
             )
         accept_token = generate_accept_token(self._nonce)
         if accept != accept_token:

--- a/src/wsproto/handshake.py
+++ b/src/wsproto/handshake.py
@@ -238,7 +238,8 @@ class H11Handshake:
             )
         if upgrade.lower() != WEBSOCKET_UPGRADE:
             raise RemoteProtocolError(
-                f"Missing header, 'Upgrade: {WEBSOCKET_UPGRADE.decode()}'", event_hint=RejectConnection()
+                f"Missing header, 'Upgrade: {WEBSOCKET_UPGRADE.decode()}'",
+                event_hint=RejectConnection(),
             )
         if host is None:
             raise RemoteProtocolError(
@@ -407,7 +408,8 @@ class H11Handshake:
             )
         if upgrade.lower() != WEBSOCKET_UPGRADE:
             raise RemoteProtocolError(
-                f"Missing header, 'Upgrade: {WEBSOCKET_UPGRADE.decode()}'", event_hint=RejectConnection()
+                f"Missing header, 'Upgrade: {WEBSOCKET_UPGRADE.decode()}'",
+                event_hint=RejectConnection(),
             )
         accept_token = generate_accept_token(self._nonce)
         if accept != accept_token:

--- a/src/wsproto/handshake.py
+++ b/src/wsproto/handshake.py
@@ -35,6 +35,9 @@ from .utilities import (
 # RFC6455, Section 4.2.1/6 - Reading the Client's Opening Handshake
 WEBSOCKET_VERSION = b"13"
 
+# RFC6455, Section 4.2.1/3 - Value of the Upgrade header
+WEBSOCKET_UPGRADE = b"websocket"
+
 
 class H11Handshake:
     """A Handshake implementation for HTTP/1.1 connections."""
@@ -233,9 +236,9 @@ class H11Handshake:
             raise RemoteProtocolError(
                 "Missing header, 'Sec-WebSocket-Key'", event_hint=RejectConnection()
             )
-        if upgrade.lower() != b"websocket":
+        if upgrade.lower() != WEBSOCKET_UPGRADE:
             raise RemoteProtocolError(
-                "Missing header, 'Upgrade: websocket'", event_hint=RejectConnection()
+                f"Missing header, 'Upgrade: {WEBSOCKET_UPGRADE.decode()}'", event_hint=RejectConnection()
             )
         if host is None:
             raise RemoteProtocolError(
@@ -260,7 +263,7 @@ class H11Handshake:
         accept_token = generate_accept_token(nonce)
 
         headers = [
-            (b"Upgrade", b"websocket"),
+            (b"Upgrade", WEBSOCKET_UPGRADE),
             (b"Connection", b"Upgrade"),
             (b"Sec-WebSocket-Accept", accept_token),
         ]
@@ -327,7 +330,7 @@ class H11Handshake:
 
         headers = [
             (b"Host", request.host.encode("idna")),
-            (b"Upgrade", b"websocket"),
+            (b"Upgrade", WEBSOCKET_UPGRADE),
             (b"Connection", b"Upgrade"),
             (b"Sec-WebSocket-Key", self._nonce),
             (b"Sec-WebSocket-Version", WEBSOCKET_VERSION),
@@ -402,9 +405,9 @@ class H11Handshake:
             raise RemoteProtocolError(
                 "Missing header, 'Connection: Upgrade'", event_hint=RejectConnection()
             )
-        if upgrade.lower() != b"websocket":
+        if upgrade.lower() != WEBSOCKET_UPGRADE:
             raise RemoteProtocolError(
-                "Missing header, 'Upgrade: websocket'", event_hint=RejectConnection()
+                f"Missing header, 'Upgrade: {WEBSOCKET_UPGRADE.decode()}'", event_hint=RejectConnection()
             )
         accept_token = generate_accept_token(self._nonce)
         if accept != accept_token:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -40,7 +40,7 @@ def test_connection_request() -> None:
     assert headers[b"connection"] == b"Upgrade"
     assert headers[b"host"] == b"localhost"
     assert headers[b"sec-websocket-version"] == b"13"
-    assert headers[b"upgrade"] == b"WebSocket"
+    assert headers[b"upgrade"] == b"websocket"
     assert b"sec-websocket-key" in headers
 
 
@@ -119,7 +119,7 @@ def test_connection_send_state() -> None:
         status_code=101,
         headers=[
             (b"connection", b"Upgrade"),
-            (b"upgrade", b"WebSocket"),
+            (b"upgrade", b"websocket"),
             (
                 b"Sec-WebSocket-Accept",
                 generate_accept_token(headers[b"sec-websocket-key"]),
@@ -178,14 +178,14 @@ def _make_handshake(
 
 def test_handshake() -> None:
     events = _make_handshake(
-        101, [(b"connection", b"Upgrade"), (b"upgrade", b"WebSocket")]
+        101, [(b"connection", b"Upgrade"), (b"upgrade", b"websocket")]
     )
     assert events == [AcceptConnection()]
 
 
 def test_broken_handshake() -> None:
     events = _make_handshake(
-        102, [(b"connection", b"Upgrade"), (b"upgrade", b"WebSocket")]
+        102, [(b"connection", b"Upgrade"), (b"upgrade", b"websocket")]
     )
     assert isinstance(events[0], RejectConnection)
     assert events[0].status_code == 102
@@ -194,7 +194,7 @@ def test_broken_handshake() -> None:
 def test_handshake_extra_accept_headers() -> None:
     events = _make_handshake(
         101,
-        [(b"connection", b"Upgrade"), (b"upgrade", b"WebSocket"), (b"X-Foo", b"bar")],
+        [(b"connection", b"Upgrade"), (b"upgrade", b"websocket"), (b"X-Foo", b"bar")],
     )
     assert events == [AcceptConnection(extra_headers=[(b"x-foo", b"bar")])]
 
@@ -202,7 +202,7 @@ def test_handshake_extra_accept_headers() -> None:
 @pytest.mark.parametrize("extra_headers", [[], [(b"connection", b"Keep-Alive")]])
 def test_handshake_response_broken_connection_header(extra_headers: Headers) -> None:
     with pytest.raises(RemoteProtocolError) as excinfo:
-        _make_handshake(101, [(b"upgrade", b"WebSocket")] + extra_headers)
+        _make_handshake(101, [(b"upgrade", b"websocket")] + extra_headers)
     assert str(excinfo.value) == "Missing header, 'Connection: Upgrade'"
 
 
@@ -210,14 +210,14 @@ def test_handshake_response_broken_connection_header(extra_headers: Headers) -> 
 def test_handshake_response_broken_upgrade_header(extra_headers: Headers) -> None:
     with pytest.raises(RemoteProtocolError) as excinfo:
         _make_handshake(101, [(b"connection", b"Upgrade")] + extra_headers)
-    assert str(excinfo.value) == "Missing header, 'Upgrade: WebSocket'"
+    assert str(excinfo.value) == "Missing header, 'Upgrade: websocket'"
 
 
 def test_handshake_response_missing_websocket_key_header() -> None:
     with pytest.raises(RemoteProtocolError) as excinfo:
         _make_handshake(
             101,
-            [(b"connection", b"Upgrade"), (b"upgrade", b"WebSocket")],
+            [(b"connection", b"Upgrade"), (b"upgrade", b"websocket")],
             auto_accept_key=False,
         )
     assert str(excinfo.value) == "Bad accept token"
@@ -228,7 +228,7 @@ def test_handshake_with_subprotocol() -> None:
         101,
         [
             (b"connection", b"Upgrade"),
-            (b"upgrade", b"WebSocket"),
+            (b"upgrade", b"websocket"),
             (b"sec-websocket-protocol", b"one"),
         ],
         subprotocols=["one", "two"],
@@ -242,7 +242,7 @@ def test_handshake_bad_subprotocol() -> None:
             101,
             [
                 (b"connection", b"Upgrade"),
-                (b"upgrade", b"WebSocket"),
+                (b"upgrade", b"websocket"),
                 (b"sec-websocket-protocol", b"new"),
             ],
         )
@@ -255,7 +255,7 @@ def test_handshake_with_extension() -> None:
         101,
         [
             (b"connection", b"Upgrade"),
-            (b"upgrade", b"WebSocket"),
+            (b"upgrade", b"websocket"),
             (b"sec-websocket-extensions", b"fake"),
         ],
         extensions=[extension],
@@ -269,7 +269,7 @@ def test_handshake_bad_extension() -> None:
             101,
             [
                 (b"connection", b"Upgrade"),
-                (b"upgrade", b"WebSocket"),
+                (b"upgrade", b"websocket"),
                 (b"sec-websocket-extensions", b"bad, foo"),
             ],
         )

--- a/test/test_handshake.py
+++ b/test/test_handshake.py
@@ -40,7 +40,7 @@ def test_rejected_handshake(http: bytes) -> None:
     with pytest.raises(RemoteProtocolError):
         server.receive_data(
             b"GET / " + http + b"\r\n"
-            b"Upgrade: WebSocket\r\n"
+            b"Upgrade: websocket\r\n"
             b"Connection: Upgrade\r\n"
             b"Sec-WebSocket-Key: VQr8cvwwZ1fEk62PDq8J3A==\r\n"
             b"Sec-WebSocket-Version: 13\r\n"

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -33,7 +33,7 @@ def test_connection_request() -> None:
         [
             (b"Host", b"localhost"),
             (b"Connection", b"Keep-Alive, Upgrade"),
-            (b"Upgrade", b"WebSocket"),
+            (b"Upgrade", b"websocket"),
             (b"Sec-WebSocket-Version", b"13"),
             (b"Sec-WebSocket-Key", generate_nonce()),
             (b"X-Foo", b"bar"),
@@ -50,7 +50,7 @@ def test_connection_request() -> None:
     assert b"sec-websocket-protocol" not in headers
     assert headers[b"connection"] == b"Keep-Alive, Upgrade"
     assert headers[b"sec-websocket-version"] == b"13"
-    assert headers[b"upgrade"] == b"WebSocket"
+    assert headers[b"upgrade"] == b"websocket"
     assert headers[b"x-foo"] == b"bar"
 
 
@@ -60,7 +60,7 @@ def test_connection_request_bad_method() -> None:
             [
                 (b"Host", b"localhost"),
                 (b"Connection", b"Keep-Alive, Upgrade"),
-                (b"Upgrade", b"WebSocket"),
+                (b"Upgrade", b"websocket"),
                 (b"Sec-WebSocket-Version", b"13"),
                 (b"Sec-WebSocket-Key", generate_nonce()),
             ],
@@ -75,7 +75,7 @@ def test_connection_request_bad_connection_header() -> None:
             [
                 (b"Host", b"localhost"),
                 (b"Connection", b"Keep-Alive, No-Upgrade"),
-                (b"Upgrade", b"WebSocket"),
+                (b"Upgrade", b"websocket"),
                 (b"Sec-WebSocket-Version", b"13"),
                 (b"Sec-WebSocket-Key", generate_nonce()),
             ]
@@ -94,7 +94,7 @@ def test_connection_request_bad_upgrade_header() -> None:
                 (b"Sec-WebSocket-Key", generate_nonce()),
             ]
         )
-    assert str(excinfo.value) == "Missing header, 'Upgrade: WebSocket'"
+    assert str(excinfo.value) == "Missing header, 'Upgrade: websocket'"
 
 
 @pytest.mark.parametrize("version", [b"12", b"not-a-digit"])
@@ -104,7 +104,7 @@ def test_connection_request_bad_version_header(version: bytes) -> None:
             [
                 (b"Host", b"localhost"),
                 (b"Connection", b"Keep-Alive, Upgrade"),
-                (b"Upgrade", b"WebSocket"),
+                (b"Upgrade", b"websocket"),
                 (b"Sec-WebSocket-Version", version),
                 (b"Sec-WebSocket-Key", generate_nonce()),
             ]
@@ -121,7 +121,7 @@ def test_connection_request_key_header() -> None:
             [
                 (b"Host", b"localhost"),
                 (b"Connection", b"Keep-Alive, Upgrade"),
-                (b"Upgrade", b"WebSocket"),
+                (b"Upgrade", b"websocket"),
                 (b"Sec-WebSocket-Version", b"13"),
             ]
         )
@@ -134,7 +134,7 @@ def test_upgrade_request() -> None:
         [
             (b"Host", b"localhost"),
             (b"Connection", b"Keep-Alive, Upgrade"),
-            (b"Upgrade", b"WebSocket"),
+            (b"Upgrade", b"websocket"),
             (b"Sec-WebSocket-Version", b"13"),
             (b"Sec-WebSocket-Key", generate_nonce()),
             (b"X-Foo", b"bar"),
@@ -154,7 +154,7 @@ def test_upgrade_request() -> None:
     assert b"sec-websocket-protocol" not in headers
     assert headers[b"connection"] == b"Keep-Alive, Upgrade"
     assert headers[b"sec-websocket-version"] == b"13"
-    assert headers[b"upgrade"] == b"WebSocket"
+    assert headers[b"upgrade"] == b"websocket"
     assert headers[b"x-foo"] == b"bar"
 
 
@@ -175,7 +175,7 @@ def _make_handshake(
                 headers=[
                     (b"Host", b"localhost"),
                     (b"Connection", b"Keep-Alive, Upgrade"),
-                    (b"Upgrade", b"WebSocket"),
+                    (b"Upgrade", b"websocket"),
                     (b"Sec-WebSocket-Version", b"13"),
                     (b"Sec-WebSocket-Key", nonce),
                 ]
@@ -203,7 +203,7 @@ def test_handshake() -> None:
     assert sorted(response.headers) == [
         (b"connection", b"Upgrade"),
         (b"sec-websocket-accept", generate_accept_token(nonce)),
-        (b"upgrade", b"WebSocket"),
+        (b"upgrade", b"websocket"),
     ]
 
 
@@ -214,7 +214,7 @@ def test_handshake_extra_headers() -> None:
     assert sorted(response.headers) == [
         (b"connection", b"Upgrade"),
         (b"sec-websocket-accept", generate_accept_token(nonce)),
-        (b"upgrade", b"WebSocket"),
+        (b"upgrade", b"websocket"),
         (b"x-foo", b"bar"),
     ]
 
@@ -298,7 +298,7 @@ def _make_handshake_rejection(
                 headers=[
                     (b"Host", b"localhost"),
                     (b"Connection", b"Keep-Alive, Upgrade"),
-                    (b"Upgrade", b"WebSocket"),
+                    (b"Upgrade", b"websocket"),
                     (b"Sec-WebSocket-Version", b"13"),
                     (b"Sec-WebSocket-Key", nonce),
                 ],


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.1 the "Upgrade" header should have the value "websocket", and the server should treat it as case-insensitive.

However, sadly some servers don't respect that case-insentitivity, so better to use exactly the string as specified in the RFC.

That's what the other websocket implementations do. See for example: https://github.com/python-websockets/websockets/blob/94dd203f63bb52b1a30faa228e63ada2f0f2e874/src/websockets/client.py#L119