### PR TITLE
Add wsproto.Connection reference

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,34 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: docs/source/requirements.txt
+   - method: pip
+     path: .

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ graft docs
 graft test
 graft bench
 prune docs/build
-include README.rst LICENSE CHANGELOG.rst tox.ini
+include README.rst LICENSE CHANGELOG.rst tox.ini .readthedocs.yaml
 global-exclude *.pyc *.pyo *.swo *.swp *.map *.yml *.DS_Store .coverage

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,6 +19,10 @@ Connection
    :special-members: __init__
    :members:
 
+.. autoclass:: wsproto.Connection
+   :special-members: __init__
+   :members:
+
 .. autoclass:: wsproto.ConnectionType
    :members:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ master_doc = 'index'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme

--- a/src/wsproto/__init__.py
+++ b/src/wsproto/__init__.py
@@ -4,6 +4,7 @@ wsproto
 
 A WebSocket implementation.
 """
+
 from typing import Generator, Optional, Union
 
 from .connection import Connection, ConnectionState, ConnectionType

--- a/src/wsproto/connection.py
+++ b/src/wsproto/connection.py
@@ -63,11 +63,6 @@ class Connection:
     This wraps two other protocol objects, an HTTP/1.1 protocol object used
     to do the initial HTTP upgrade handshake and a WebSocket frame protocol
     object used to exchange messages and other control frames.
-
-    :param conn_type: Whether this object is on the client- or server-side of
-        a connection. To initialise as a client pass ``CLIENT`` otherwise
-        pass ``SERVER``.
-    :type conn_type: ``ConnectionType``
     """
 
     def __init__(
@@ -76,6 +71,16 @@ class Connection:
         extensions: Optional[List[Extension]] = None,
         trailing_data: bytes = b"",
     ) -> None:
+        """
+        Constructor
+
+        :param wsproto.connection.ConnectionType connection_type: Whether this
+            object is on the client- or server-side of a connection.
+            To initialise as a client pass ``CLIENT`` otherwise pass ``SERVER``.
+        :param list extensions: The proposed extensions.
+        :param bytes trailing_data: Data that has been received, but not yet
+            processed.
+        """
         self.client = connection_type is ConnectionType.CLIENT
         self._events: Deque[Event] = deque()
         self._proto = FrameProtocol(self.client, extensions or [])

--- a/src/wsproto/events.py
+++ b/src/wsproto/events.py
@@ -4,6 +4,7 @@ wsproto/events
 
 Events that result from processing data on a WebSocket connection.
 """
+
 from abc import ABC
 from dataclasses import dataclass, field
 from typing import Generic, List, Optional, Sequence, TypeVar, Union
@@ -156,7 +157,6 @@ class RejectData(Event):
 
 @dataclass(frozen=True)
 class CloseConnection(Event):
-
     """The end of a Websocket connection, represents a closure frame.
 
     **wsproto does not automatically send a response to a close event.** To

--- a/src/wsproto/handshake.py
+++ b/src/wsproto/handshake.py
@@ -4,6 +4,7 @@ wsproto/handshake
 
 An implementation of WebSocket handshakes.
 """
+
 from collections import deque
 from typing import (
     cast,

--- a/src/wsproto/utilities.py
+++ b/src/wsproto/utilities.py
@@ -4,6 +4,7 @@ wsproto/utilities
 
 Utility functions that do not belong in a separate module.
 """
+
 import base64
 import hashlib
 import os

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 
 [testenv:docs]
 deps =
-    sphinx
+    -r docs/source/requirements.txt
 allowlist_externals = make
 changedir = {toxinidir}/docs
 commands =


### PR DESCRIPTION
Hello! I have made some minor document corrections.

## Summary

1. Add `wsproto.Connection` reference
    `wsproto.Connection` is described in [Post handshake connection](https://python-hyper.org/projects/wsproto/en/latest/advanced-usage.html#post-handshake-connection), but it is not listed in the API reference in the documentation. It would be useful to see this in the documentation. Added autodoc directives to `api.rst` and fixed docstrings.

2. Fix Read the Docs build
    While working on the above fix, I noticed that the latest build of Read the Docs for wsproto is failing.

    https://readthedocs.org/projects/wsproto/builds/22942691/

    > Problem in your project's configuration. No default configuration file found at repository's root. See https://docs.readthedocs.io/en/stable/config-file/

    It looks like the `.readthedocs.yaml` file is now required to build Read the Docs [^1]. The `.readthedocs.yaml` file has been added. Also added `requirements.txt` for the documentation, since the `sphinx-rtd-theme` is not automatically applied.

    I don't think the Read the docs preview in the pull request is set up, so I built the docs in the fork repository. You can check that here
    https://improved-octo-garbanzo.readthedocs.io/en/latest/api.html#wsproto.Connection

[^1]: https://blog.readthedocs.com/migrate-configuration-v2/