### PR TITLE
Added missing "reason" to ensure backward compatibility

### DIFF
--- a/src/wsproto/handshake.py
+++ b/src/wsproto/handshake.py
@@ -286,7 +286,7 @@ class H11Handshake:
                 headers.append((b"Sec-WebSocket-Extensions", accepts))
 
         response = h11.InformationalResponse(
-            status_code=101, headers=headers + event.extra_headers
+            status_code=101, headers=headers + event.extra_headers, reason=b"Switching Protocols"
         )
         self._connection = Connection(
             ConnectionType.CLIENT if self.client else ConnectionType.SERVER,

--- a/src/wsproto/handshake.py
+++ b/src/wsproto/handshake.py
@@ -286,7 +286,9 @@ class H11Handshake:
                 headers.append((b"Sec-WebSocket-Extensions", accepts))
 
         response = h11.InformationalResponse(
-            status_code=101, headers=headers + event.extra_headers, reason=b"Switching Protocols"
+            status_code=101,
+            headers=headers + event.extra_headers,
+            reason=b"Switching Protocols",
         )
         self._connection = Connection(
             ConnectionType.CLIENT if self.client else ConnectionType.SERVER,


### PR DESCRIPTION
Reason added for Informational response to socket connection upgrade. This ensures backwards compatibility for older socket libraries like: OCaml/websokets