### PR TITLE
Bump h11 dependency version for critical security fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'h11>=0.13.0,<1',
+        'h11>=0.16.0,<1',
     ],
 )


### PR DESCRIPTION
A critical CVE affecting h11 < 0.16.0 has been published: [CVE-2025-43859](https://github.com/advisories/GHSA-vqfr-h8mv-ghfj)