### PR TITLE
Update installation instructions to remove setup.py

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,6 +12,6 @@ from `our GitHub repository`_ and run:
 
 .. code-block:: console
 
-    $ python setup.py install
+    $ pip install --editable .
 
 .. _our GitHub repository: https://github.com/python-hyper/wsproto


### PR DESCRIPTION
`setup.py` was removed in:
* #193