### PR TITLE
Require event hints for remote protocol errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+1.4.0 (unreleased)
+------------------
+
+- Require ``event_hint`` when constructing ``RemoteProtocolError``.
+  This is an API-breaking change.
+
 1.3.2 (2025-11-20)
 ------------------
 

--- a/src/wsproto/utilities.py
+++ b/src/wsproto/utilities.py
@@ -47,12 +47,12 @@ class RemoteProtocolError(ProtocolError):
 
     .. attribute:: event_hint
 
-       This is a suggested wsproto Event to send to the client based
-       on the error. It could be None if no hint is available.
+       This is the suggested wsproto Event to send to the client based
+       on the error.
 
     """
 
-    def __init__(self, message: str, event_hint: Event | None = None) -> None:
+    def __init__(self, message: str, event_hint: Event) -> None:
         self.event_hint = event_hint
         super().__init__(message)
 

--- a/src/wsproto/utilities.py
+++ b/src/wsproto/utilities.py
@@ -50,9 +50,11 @@ class RemoteProtocolError(ProtocolError):
        This is the suggested wsproto Event to send to the client based
        on the error.
 
+    .. versionchanged:: 1.4.0
+       Made ``event_hint`` a required argument.
+
     """
 
-    # API-breaking change for the next minor release: event_hint is required.
     def __init__(self, message: str, event_hint: Event) -> None:
         self.event_hint = event_hint
         super().__init__(message)

--- a/src/wsproto/utilities.py
+++ b/src/wsproto/utilities.py
@@ -52,6 +52,7 @@ class RemoteProtocolError(ProtocolError):
 
     """
 
+    # API-breaking change for the next minor release: event_hint is required.
     def __init__(self, message: str, event_hint: Event) -> None:
         self.event_hint = event_hint
         super().__init__(message)


### PR DESCRIPTION
## Summary
- make `RemoteProtocolError.event_hint` a required constructor argument
- update the public documentation to match the guarantee already provided by all internal call sites

## Why
Issue #178 notes that every `wsproto` call site already supplies an `event_hint`, while the public signature still allows callers to construct a `RemoteProtocolError` without one. Requiring the argument makes the API describe the behavior the implementation already depends on and gives consumers a stable hint to react to.

This is intentionally an API-breaking change, matching the maintainer note that the issue is a candidate for a future minor API-breaking release.

## Validation
- Not run locally
- Verified statically that all in-repo `RemoteProtocolError(...)` call sites already provide `event_hint=`.
- Relying on the repository's remote CI for execution feedback.